### PR TITLE
Add netcdf safe save and load functions

### DIFF
--- a/simpl/simpl.py
+++ b/simpl/simpl.py
@@ -16,7 +16,7 @@ import time
 
 # Internal libraries
 import simpl
-from simpl.utils import coefficient_of_determination, cca, create_speckled_mask, gaussian_sample
+from simpl.utils import coefficient_of_determination, cca, create_speckled_mask, gaussian_sample, save_results_to_netcdf
 from simpl.environment import Environment
 
 # Kalmax package handles the Kalman filtering and KDE
@@ -1107,14 +1107,14 @@ class SIMPL:
             try: pbar.set_description(f"Epoch {max(0,self.epoch)}")
             except: pass
 
-    def save_results(self, path:str):
+    def save_results(self, path: str):
         """Saves the results of the SIMPL model to a netCDF file at the given path. The results are saved as an xarray Dataset. 
-        
+
         Parameters
         ----------
         path : str
             The path to save the results to.
         """
-        self.results.to_netcdf(path)
+        save_results_to_netcdf(self.results, path)
 if __name__ == "__main__":
     pass


### PR DESCRIPTION
This pull request addresses an issue in the save functions as reported [here](https://github.com/TomGeorge1234/SIMPL/issues/5).

`.to_netcdf()` function does not accept boolean data. The modified code converts boolean to int. 

I chose not to create a general-purpose data conversion function, as only a few specific conversions are currently needed.
Please note that when new variables are added, the save_results and load_results functions may require corresponding updates.

Since the importance of the `overdispersion` variable is unclear, I’ve excluded it from being saved for now.
There is a separate [issue](https://github.com/TomGeorge1234/SIMPL/issues/8) open to discuss this matter further.

## TODO
Modify how `overdispersion` is calculated such that it will have a shape of (epoch, neuron)
probably @TomGeorge1234 ?