### PR TITLE
Add circular_kde for M step

### DIFF
--- a/simpl/simpl.py
+++ b/simpl/simpl.py
@@ -21,7 +21,7 @@ from simpl.environment import Environment
 
 # Kalmax package handles the Kalman filtering and KDE
 from kalmax.kalman import KalmanFilter
-from kalmax.kde import kde, circular_kde
+from kalmax.kde import kde, kde_circular1d
 from kalmax.kde import poisson_log_likelihood, poisson_log_likelihood_trajectory
 from kalmax.utils import fit_gaussian
 from kalmax.kernels import gaussian_kernel
@@ -115,6 +115,10 @@ class SIMPL:
             If False, the results can only be saved at the end of the training when self.evaluate_epoch() is manually called. Epoch 0 is also always evaluated.
         save_likelihood_maps : bool, optional
             Whether to save the likelihood maps of the spikes at each time step (these a size env x time so cost a LOT of memory, only save if needed), by default False
+        is_circular : bool, optional
+            Whether the latent space is circular (e.g. head direction data). If True, a kde_circular1d is used in the M-step, by default False. 
+            Currently it only supports 1D circular data, so if True, the environment should have D=1.
+            It expects the coordinates of the environment to be in radians and to range from -pi to pi.
 
         
         """
@@ -229,7 +233,7 @@ class SIMPL:
 
         self.is_circular = is_circular
         if is_circular:
-            self.kde = circular_kde
+            self.kde = kde_circular1d
         else:
             self.kde = kde
     


### PR DESCRIPTION
This PR updates the M-step to use `circular_kde`.
It relies on the updated `kde` implementation (PR: https://github.com/TomGeorge1234/KalMax/pull/2).

Currently, the input values are expected to be in the range (-π, π). When setting up the environment, please ensure that `force_lims` is specified:

```
env = Environment(
    X=data.Xb.data,
    bin_size=2 * np.pi / 60,
    force_lims=[[-np.pi], [np.pi]],
    pad=0,
)
```

When instantiating `SIMPL`, `kernel_bandwidth` corresponds to the κ (kappa) parameter of the von Mises distribution.
