### PR TITLE
Add assertion for manifold_align_against

### DIFF
--- a/src/simpl/simpl.py
+++ b/src/simpl/simpl.py
@@ -276,9 +276,7 @@ class SIMPL:
 
         # MANIFOLD ALIGNMENT
         if manifold_align_against not in {"behaviour", "ground_truth", "none"}:
-            raise ValueError(
-                "manifold_align_against must be 'behaviour', 'ground_truth', 'none'"
-            )
+            raise ValueError("manifold_align_against must be 'behaviour', 'ground_truth', 'none'")
 
         if manifold_align_against == "behaviour":
             self.Xalign = self.Xb


### PR DESCRIPTION
When I was changing the parameter `manifold_align_against`, I assumed the default was None. 
I think other people could make the same confusion. Let's add an assertion to prevent this!