### PR TITLE
Skip kalman argument

### DIFF
--- a/src/simpl/simpl.py
+++ b/src/simpl/simpl.py
@@ -35,7 +35,7 @@ class SIMPL:
         # Model parameters
         kernel_bandwidth: float = 0.02,
         speed_prior: float = 0.1,
-        kalman: bool = True,
+        use_kalman_smoothing: bool = True,
         behaviour_prior: float | None = None,
         is_circular: bool = False,
         # Mask and analysis parameters
@@ -115,7 +115,7 @@ class SIMPL:
         speed_prior : float, optional
             The prior speed of the agent in units of meters per second, by default 0.1 m/s.
             This controls process noise in the internal Kalman model.
-        kalman : bool, optional
+        use_kalman_smoothing : bool, optional
             Whether to use standard Kalman smoothing dynamics, by default True.
             If False, SIMPL still runs the Kalman filter/smoother internally, but enforces a very
             high effective speed prior so the smoothed trajectory (`mu_s`) becomes very close to the
@@ -196,10 +196,12 @@ class SIMPL:
         self.kernel_bandwidth = kernel_bandwidth
 
         # Kalman configuration
-        self.kalman = kalman
+        self.use_kalman_smoothing = use_kalman_smoothing
         self.speed_prior_requested = speed_prior
         self.kalman_off_speed_prior = 1e10
-        self.speed_prior_effective = speed_prior if self.kalman else max(speed_prior, self.kalman_off_speed_prior)
+        self.speed_prior_effective = (
+            speed_prior if self.use_kalman_smoothing else max(speed_prior, self.kalman_off_speed_prior)
+        )
 
         # CREATE SPIKE MASKS
         self.resample_spike_mask = resample_spike_mask
@@ -474,7 +476,7 @@ class SIMPL:
 
         Notes
         -----
-        If `self.kalman=False`, this step still uses the same Kalman equations internally but with
+        If `self.use_kalman_smoothing=False`, this step still uses the same Kalman equations internally but with
         very high process noise, so smoothing has minimal effect and `mu_s` should stay close to
         `mode_l`.
 

--- a/tests/test_simpl.py
+++ b/tests/test_simpl.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from simpl.environment import Environment
 from simpl.simpl import SIMPL
-from simpl.utils import load_datafile, load_results, prepare_data
+from simpl.utils import load_results, prepare_data
 
 
 class TestSIMPLInit:
@@ -20,7 +20,7 @@ class TestSIMPLInit:
         assert model.D == 2
         assert model.epoch == 0  # epoch 0 runs in __init__
 
-    def test_kalman_argument_exposed(self, demo_data):
+    def test_use_kalman_smoothing_argument(self, demo_data):
         N = 500
         N_neurons = min(5, demo_data["Y"].shape[1])
         data = prepare_data(
@@ -31,9 +31,9 @@ class TestSIMPLInit:
             neurons=np.arange(N_neurons),
         )
         env = Environment(demo_data["Xb"][:N], verbose=False)
-        model = SIMPL(data=data, environment=env, kalman=False, speed_prior=0.1)
-        assert model.kalman is False
-        # kalman=False should enforce a high effective speed prior.
+        model = SIMPL(data=data, environment=env, use_kalman_smoothing=False, speed_prior=0.1)
+        assert model.use_kalman_smoothing is False
+        # use_kalman_smoothing=False should enforce a high effective speed prior.
         assert model.speed_prior_effective >= model.kalman_off_speed_prior
 
 


### PR DESCRIPTION
Following the discussion [here](https://github.com/TomGeorge1234/SIMPL/issues/17), I added a boolean argument `kalman` so that users can explicitly choose whether or not to use Kalman smoothing.

With some experimenting, I concluded that speed prior needs to be very high in order for `mode_l` and `mu_s` to match (1e10).

In `test_simply.py`, I adopted a strict criterion using `np.all_close`, since we are telling the users that 
"If `kalman=False`, `mode_l == mu_s`"