### PR TITLE
Jax metal gpu

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,11 +158,13 @@ model = SIMPL(use_gpu=False)
 
 #### Apple Silicon GPU (experimental)
 
-SIMPL supports Apple Metal GPU acceleration via [`jax-metal`](https://developer.apple.com/metal/jax/). This is experimental but has been observed to give a decent (~2x) speed-up for large datasets. It requires JAX 0.4.35:
+SIMPL supports Apple Metal GPU acceleration via [`jax-metal`](https://developer.apple.com/metal/jax/). This is experimental (use with caution, ) but has been observed to give a decent (~2x) speed-up for large datasets:
 
 ```bash
-pip install jax==0.4.35 jaxlib==0.4.35 jax-metal
+pip install .[metal]
 ```
+
+> **Note:** This pins JAX to 0.4.35, which is older than the latest release. If other packages in your environment require a newer JAX, consider using a separate venv or sticking to CPU/CUDA-GPUs.
 
 No code changes are needed — SIMPL auto-detects Metal and uses it for KDE and log-likelihood computation. The Kalman filter runs on CPU automatically. Angular mode (`is_1D_angular=True`) falls back to CPU as Metal lacks FFT support. We intend to make metal support default when `jax-metal` is ready. 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,11 @@ docs = [
     "mkdocstrings[python]",
     "mkdocs-include-markdown-plugin",
 ]
+metal = [
+    "jax==0.4.35",
+    "jaxlib==0.4.35",
+    "jax-metal",
+]
 dev = [
     "pytest>=7.0",
     "pytest-cov",

--- a/src/simpl/kalman.py
+++ b/src/simpl/kalman.py
@@ -705,17 +705,12 @@ def _kalman_smoother(
         # Standard RTS smoother step
         mu_predict, sigma_predict = _kalman_predict(mu_f_t, sigma_f_t, F, Q, B, u)
         mu_predict = jnp.where(is_1D_angular, _wrap_minuspi_pi(mu_predict), mu_predict)
-        sigma_predict = sigma_predict + jnp.eye(sigma_predict.shape[0]) * 1e-6
         J = sigma_f_t @ F.T @ jnp.linalg.inv(sigma_predict)
         diff = mu_s_next - mu_predict
         diff = jnp.where(is_1D_angular, _wrap_minuspi_pi(diff), diff)
         mu_smoothed = mu_f_t + J @ diff
         mu_smoothed = jnp.where(is_1D_angular, _wrap_minuspi_pi(mu_smoothed), mu_smoothed)
         sigma_smoothed = sigma_f_t + J @ (sigma_s_next - sigma_predict) @ J.T
-        # Fall back to filtered value if smoothing produced NaN (numerical instability)
-        has_nan = jnp.any(jnp.isnan(mu_smoothed)) | jnp.any(jnp.isnan(sigma_smoothed))
-        mu_smoothed = jnp.where(has_nan, mu_f_t, mu_smoothed)
-        sigma_smoothed = jnp.where(has_nan, sigma_f_t, sigma_smoothed)
         # At trial ends: override with filtered value (terminal condition)
         mu_out = jnp.where(is_end, mu_f_t, mu_smoothed)
         sigma_out = jnp.where(is_end, sigma_f_t, sigma_smoothed)


### PR DESCRIPTION
Minor changes on top of last PR

Added a `pip install -e.[metal]` option for those users wanting to use experimental jax metal 