### PR TITLE
Compare log-likelihood metrics between SIMPL, maximum likelihood decoding, and behaviour

### DIFF
--- a/docs/api/utils.md
+++ b/docs/api/utils.md
@@ -36,8 +36,6 @@
 
 ::: simpl.utils.load_demo_data
 
-::: simpl.utils.print_data_summary
-
 ::: simpl.utils.save_results_to_netcdf
 
 ::: simpl.utils.load_results

--- a/examples/simpl_demo.ipynb
+++ b/examples/simpl_demo.ipynb
@@ -293,6 +293,15 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pc_model.plot_fitting_summary(show_neurons=False);"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -445,6 +454,15 @@
     "    behavior_prior=2.0,\n",
     ")\n",
     "hd_model.fit(Y_hd, Xb_hd, time_hd, n_iterations=20, trial_boundaries=trial_boundaries_hd)\n",
+    "hd_model.plot_fitting_summary();"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "hd_model.plot_fitting_summary();"
    ]
   },

--- a/src/simpl/kde.py
+++ b/src/simpl/kde.py
@@ -9,8 +9,8 @@ For 1-D angular environments (``is_1D_angular=True``), the specialised
 ``kde_angular`` function convolves with a wrapped Gaussian kernel via FFT so
 that the estimate is seamless across the \\([-\\pi, \\pi)\\) boundary.
 
-The Poisson log-likelihood functions (``poisson_log_likelihood`` and
-``poisson_log_likelihood_trajectory``) evaluate how well the estimated
+The Poisson log-likelihood functions (``poisson_log_likelihood_maps`` and
+``poisson_log_likelihood``) evaluate how well the estimated
 receptive fields explain the observed spike counts and are used during the
 E-step to construct likelihood maps over position space."""
 
@@ -28,9 +28,16 @@ __all__ = [
     "gaussian_kernel",
     "kde",
     "kde_angular",
+    "poisson_log_likelihood_maps",
     "poisson_log_likelihood",
-    "poisson_log_likelihood_trajectory",
+    "get_ll_and_bps_splits",
 ]
+
+
+def _log_factorial_stirling(spikes: jax.Array) -> jax.Array:
+    """Stirling's approximation of log(spikes!), with manual correction for 0! = 1."""
+    spikes_ = jnp.where(spikes == 0, 1, spikes)
+    return jnp.log(jnp.sqrt(2 * jnp.pi)) + (spikes_ + 0.5) * jnp.log(spikes_) - spikes_
 
 
 def gaussian_kernel(
@@ -187,76 +194,124 @@ def kde(
 
 def poisson_log_likelihood(
     spikes: jax.Array,
-    mean_rate: jax.Array,
-    mask: jax.Array | None = None,
-    renormalise: bool = True,
+    rates: jax.Array,
 ) -> jax.Array:
-    """Takes an array of spike counts and an array of mean rates and returns
-    the log-likelihood of the spikes given the mean rate of the neuron
-    (its receptive field).
+    """Per-element Poisson log-likelihood of spike counts given predicted rates.
 
     The Poisson probability of observing \\(X\\) spikes given mean rate \\(\\mu\\) is:
 
     $$P(X \\mid \\mu) = \\frac{\\mu^X \\, e^{-\\mu}}{X!}$$
 
-    The log-likelihood summed over neurons is:
+    so the log-likelihood is:
 
-    $$\\log P(X \\mid \\mu) = \\sum_{\\text{neurons}} \\left[ X \\log \\mu - \\mu - \\log(X!) \\right]$$
+    $$\\log P(X \\mid \\mu) = X \\log \\mu - \\mu - \\log(X!)$$
 
     where \\(\\log(X!)\\) is computed via Stirling's approximation (manually
     correcting for when \\(X = 0\\)):
 
     $$\\log(X!) \\approx \\log\\sqrt{2\\pi} + (X + 0.5)\\log X - X$$
 
-    This Stirling's approximation IS necessary as it avoids computing
-    \\(n!\\) directly, which can be enormous and produce NaNs for large spike
-    counts.
-
-    Optionally, a boolean mask same shape as spikes can be passed to ignore
-    certain spikes. This restricts the likelihood calculation to only the
-    spikes where mask is True.
+    Accepts arrays of any shape; ``spikes`` and ``rates`` must share the same
+    shape. Returns an array of that same shape.
 
     Parameters
     ----------
-    spikes : jax.Array, shape (T, N_neurons,)
-        How many spikes the neuron actually fired at each bin (int, can be > 1)
-    mean_rate : jax.Array, shape (N_neurons, N_bins,)
-        The mean rate of the neuron (it's receptive field) at each bin.
-        This is how many spikes you would _expect_ in at this position
-        in a time dt.
-    mask : jax.Array, shape (T, N_neurons,), optional
-        A boolean mask to apply to the spikes. If None, no mask is applied. Default is None.
-    renormalise : bool, optional
-        If True this renormalises so the maximum log-likelihood is always 0
-        (max likelihood is 1). Recommended to avoid nan errors when
-        likelihoods are small. Default is True.
+    spikes : jax.Array
+        Observed spike counts.
+    rates : jax.Array
+        Predicted firing rates (expected spikes per time bin). Same shape as ``spikes``.
 
     Returns
     -------
-    log_likelihood : jax.Array, shape (T, N_bins,)
-        The log-likelihood (summed over neurons) of the spikes given the mean rate of the neuron
+    log_likelihood : jax.Array
+        Per-element Poisson log-likelihood. Same shape as inputs.
     """
-    # If not passed make a no-mask mask (all True)
+    assert spikes.shape == rates.shape, f"spikes {spikes.shape} and rates {rates.shape} must have the same shape"
+
+    log_spikecount_factorial = _log_factorial_stirling(spikes)
+
+    return (spikes * jnp.log(rates + 1e-3)) - rates - log_spikecount_factorial
+
+
+def poisson_log_likelihood_maps(
+    spikes: jax.Array,
+    mean_rate: jax.Array,
+    mask: jax.Array | None = None,
+) -> jax.Array:
+    """Version of ``poisson_log_likelihood`` optimised to broadcast over the
+    spatial binning dimension and sum over neurons.
+
+    Used in the E-step to build likelihood maps: for each time step, evaluates
+    the Poisson log-likelihood at every spatial bin simultaneously via a matrix
+    multiply ``(T, N) @ (N, B) → (T, B)``.
+
+    Parameters
+    ----------
+    spikes : jax.Array, shape (T, N_neurons)
+        Observed spike counts.
+    mean_rate : jax.Array, shape (N_neurons, N_bins)
+        Receptive fields: expected spike count per time bin at each spatial bin.
+    mask : jax.Array, shape (T, N_neurons), optional
+        Boolean spike mask. If None, all neurons are used.
+
+    Returns
+    -------
+    log_likelihood : jax.Array, shape (T, N_bins)
+        Log-likelihood summed over neurons at each spatial bin.
+    """
     if mask is None:
         mask = jnp.ones_like(spikes, dtype=bool)
 
-    # Calculate log factorial of spike counts NOTE this could be removed if you dont care about absolute likelihoods
-    spikes_ = jnp.where(spikes == 0, 1, spikes)  # replace 0 spikes with 1s because 0! = 1
-    log_spikecount_factorial = (
-        jnp.log(jnp.sqrt(2 * jnp.pi)) + (spikes_ + 0.5) * jnp.log(spikes_) - spikes_
-    )  # manually correcting for when X=0
+    log_spikecount_factorial = _log_factorial_stirling(spikes)
 
-    # Sum over neurons (which are unmasked)
-    logPXmu = (
+    return (
         (mask * spikes) @ jnp.log(mean_rate + 1e-3)
         - mask @ mean_rate
         - jnp.sum(log_spikecount_factorial * mask, axis=1)[:, None]
     )
 
-    # Renormalise so max likelihood is 1
-    if renormalise:
-        logPXmu = logPXmu - jnp.max(logPXmu, axis=1)[:, None]
-    return logPXmu
+
+def get_ll_and_bps_splits(
+    Y: jax.Array,
+    FX: jax.Array,
+    mask: jax.Array,
+) -> dict:
+    """Compute train/val log-likelihoods and bits-per-spike from spikes and predicted rates.
+
+    Parameters
+    ----------
+    Y : jax.Array, shape (T, N_neurons)
+        Observed spike counts.
+    FX : jax.Array, shape (T, N_neurons)
+        Predicted firing rates (expected spikes per time bin).
+    mask : jax.Array, shape (T, N_neurons)
+        Boolean training mask. True = train, False = validation.
+
+    Returns
+    -------
+    dict
+        Keys: ``logPYXF``, ``logPYXF_val``, ``bits_per_spike``, ``bits_per_spike_val``.
+    """
+    val_mask = ~mask
+    ll = poisson_log_likelihood(Y, FX)
+
+    ll_train = (ll * mask).sum()
+    ll_val = (ll * val_mask).sum()
+
+    mean_FX = (Y * mask).sum(axis=0, keepdims=True) / mask.sum(axis=0, keepdims=True)
+    mean_FX = jnp.broadcast_to(mean_FX, FX.shape)
+    ll_baseline = poisson_log_likelihood(Y, mean_FX)
+
+    LLs = {
+        "logPYXF": ll_train / mask.sum(),
+        "logPYXF_val": ll_val / val_mask.sum(),
+    }
+    for m, suffix, ll_model in [(mask, "", ll_train), (val_mask, "_val", ll_val)]:
+        ll_base = (ll_baseline * m).sum()
+        n_spikes = (Y * m).sum()
+        LLs[f"bits_per_spike{suffix}"] = jnp.where(n_spikes > 0, (ll_model - ll_base) / (n_spikes * jnp.log(2.0)), 0.0)
+
+    return {k: float(v) for k, v in LLs.items()}
 
 
 def decode_observations(
@@ -269,7 +324,7 @@ def decode_observations(
 ) -> tuple:
     """Compute Poisson likelihood maps, fit Gaussian observations, and flag silent bins.
 
-    This combines ``poisson_log_likelihood`` and ``fit_gaussian`` in a single
+    This combines ``poisson_log_likelihood_maps`` and ``fit_gaussian`` in a single
     batched pipeline so that the full ``(T, N_bins)`` likelihood tensor is never
     materialised at once, keeping peak memory low for long sessions.
 
@@ -310,7 +365,8 @@ def decode_observations(
 
     @partial(jax.jit, static_argnames=("_return_log_maps",))
     def _process_batch(xF, spikes_batch, mean_rate, mask_batch, _return_log_maps=False):
-        log_maps = poisson_log_likelihood(spikes_batch, mean_rate, mask=mask_batch)
+        log_maps = poisson_log_likelihood_maps(spikes_batch, mean_rate, mask=mask_batch)
+        log_maps = log_maps - jnp.max(log_maps, axis=1)[:, None]  # shift max to 0 to avoid NaNs in exp
         mu, mode, sigma = fit_gaussian(xF, jnp.exp(log_maps))
         no_spk = jnp.sum(spikes_batch * mask_batch, axis=1) == 0
         if _return_log_maps:
@@ -347,57 +403,6 @@ def decode_observations(
     if return_log_maps:
         return mu_l, mode_l, sigma_l, no_spikes, jnp.concatenate(log_map_batches, axis=0)
     return mu_l, mode_l, sigma_l, no_spikes
-
-
-def poisson_log_likelihood_trajectory(
-    spikes: jax.Array,
-    mean_rate_along_trajectory: jax.Array,
-    mask: jax.Array | None = None,
-) -> jax.Array:
-    """Takes an array of spike counts and an _equally shaped_ array of mean
-    rates and returns the log-likelihood of the spikes given the mean rate of
-    the neuron (its receptive field). Unlike `poisson_log_likelihood`, which
-    evaluates the likelihood over a grid of positions, this function takes a
-    trajectory of mean rates and returns the Poisson log-likelihood at each
-    time step along that trajectory. See `poisson_log_likelihood` for the
-    full formula.
-
-    Parameters
-    ----------
-    spikes : jax.Array, shape (T, N_neurons,)
-        How many spikes the neuron actually fired at each bin (int, can be > 1)
-    mean_rate_along_trajectory : jax.Array, shape (T, N_neurons,)
-        The mean rate of the neurons as calculated at each time step along
-        the trajectory. This is how many spikes you would _expect_ in at
-        this position in a time dt.
-    mask : jax.Array, shape (T, N_neurons,), optional
-        A boolean mask to apply to the spikes. If None, no mask is applied. Default is None.
-
-    Returns
-    -------
-    log_likelihood : jax.Array, shape (T,)
-        The log-likelihood (summed over neurons) of the spikes given the mean rate of the neuron
-    """
-
-    # If not passed make a no-mask mask (all True)
-    if mask is None:
-        mask = jnp.ones_like(spikes, dtype=bool)
-
-    # Calculate log factorial of spike counts NOTE this could be removed, its just a constant factor
-    spikes_ = jnp.where(spikes == 0, 1, spikes)  # replace 0 spikes with 1s because 0! = 1
-    log_spikecount_factorial = (
-        jnp.log(jnp.sqrt(2 * jnp.pi)) + (spikes_ + 0.5) * jnp.log(spikes_) - spikes_
-    )  # manually correcting for when X=0
-
-    # Calculate log-likelihood and sum over (unmasked) neurons
-    logPXmu = (
-        (spikes * jnp.log(mean_rate_along_trajectory + 1e-3))
-        - (mean_rate_along_trajectory)
-        - (log_spikecount_factorial)
-    )
-    logPXmu = jnp.sum(mask * logPXmu, axis=1)
-
-    return logPXmu
 
 
 @partial(jax.jit, static_argnames=("kernel", "return_position_density"))

--- a/src/simpl/plotting.py
+++ b/src/simpl/plotting.py
@@ -196,9 +196,49 @@ def plot_fitting_summary(
     # baseline: only iteration -1 ("best model")
     if -1 in results.iteration.values:
         if "bits_per_spike" in results:
-            ax_bps.axhline(float(results.bits_per_spike.sel(iteration=-1)), color="k", ls="--", lw=0.8)
+            y_gt = float(results.bits_per_spike.sel(iteration=-1))
+            ax_bps.axhline(y_gt, color="k", ls="--", lw=0.8)
+            ax_bps.text(
+                0.0,
+                y_gt,
+                " ground truth",
+                va="bottom",
+                ha="left",
+                fontsize="x-small",
+                color="k",
+                transform=ax_bps.get_yaxis_transform(),
+            )
         if "mutual_information" in results:
-            ax_mi.axhline(float(results.mutual_information.sel(iteration=-1).mean()), color="k", ls="--", lw=0.8)
+            y_gt_mi = float(results.mutual_information.sel(iteration=-1).mean())
+            ax_mi.axhline(y_gt_mi, color="k", ls="--", lw=0.8)
+            ax_mi.text(
+                0.0,
+                y_gt_mi,
+                " ground truth",
+                va="bottom",
+                ha="left",
+                fontsize="x-small",
+                color="k",
+                transform=ax_mi.get_yaxis_transform(),
+            )
+
+    # ML baseline
+    if "mode_l" in results and 1 in results.iteration.values:
+        from simpl.utils import get_ML_loglikelihoods
+
+        ml = get_ML_loglikelihoods(results)
+        y_ml = ml["bits_per_spike_val"]
+        ax_bps.axhline(y_ml, color="k", ls=":", lw=0.8)
+        ax_bps.text(
+            0.0,
+            y_ml,
+            " naive ML",
+            va="bottom",
+            ha="left",
+            fontsize="x-small",
+            color="k",
+            transform=ax_bps.get_yaxis_transform(),
+        )
 
     # legend on first panel
     ax_bps.plot([], [], color="gray", lw=0.8, label="train")
@@ -991,7 +1031,37 @@ def plot_all_metrics(
                     ax.plot(var_iterations[j : j + 2], vals_v[j : j + 2], color=c, lw=0.8, ls="--", zorder=3)
             # baseline: only iteration -1 ("best model")
             if -1 in baselines:
-                ax.axhline(float(da.sel(iteration=-1)), color="k", ls="--", lw=0.8)
+                y_gt = float(da.sel(iteration=-1))
+                ax.axhline(y_gt, color="k", ls="--", lw=0.8)
+                ax.text(
+                    0.0,
+                    y_gt,
+                    " ground truth",
+                    va="bottom",
+                    ha="left",
+                    fontsize="x-small",
+                    color="k",
+                    transform=ax.get_yaxis_transform(),
+                )
+            # ML baseline for LL / bps panels
+            if var_name in ("bits_per_spike", "logPYXF") and "mode_l" in results and 1 in results.iteration.values:
+                from simpl.utils import get_ML_loglikelihoods
+
+                ml = get_ML_loglikelihoods(results)
+                ml_key = f"{var_name}_val"
+                if ml_key in ml:
+                    y_ml = ml[ml_key]
+                    ax.axhline(y_ml, color="k", ls=":", lw=0.8)
+                    ax.text(
+                        0.0,
+                        y_ml,
+                        " naive ML",
+                        va="bottom",
+                        ha="left",
+                        fontsize="x-small",
+                        color="k",
+                        transform=ax.get_yaxis_transform(),
+                    )
         else:
             # per-neuron (possibly mean over place_field first)
             means = []

--- a/src/simpl/simpl.py
+++ b/src/simpl/simpl.py
@@ -1678,6 +1678,20 @@ class SIMPL:
 
         return LLs
 
+    def _get_ML_loglikelihoods(self) -> dict:
+        """Log-likelihoods for the maximum-likelihood baseline.
+
+        Scores the iteration-1 likelihood mode trajectory (``mode_l``, the
+        per-timebin ML position estimate before any Kalman smoothing) against
+        the iteration-0 receptive fields (built from behavioural positions).
+        Comparing this to iteration-0 metrics isolates the gain from ML
+        decoding alone, before SIMPL's EM refinement of the fields.
+        """
+        FX_ML = self._interpolate_firing_rates(
+            X=self.results_.mode_l.sel(iteration=1).values, F=self.results_.F.sel(iteration=0).values
+        )
+        return self._get_loglikelihoods(self.Y_, FX_ML)
+    
     def _get_metrics(
         self,
         X: jax.Array | None = None,
@@ -1773,6 +1787,7 @@ class SIMPL:
             metrics["mutual_information"] = utils.calculate_mutual_information(F, PX, self.dt_)
 
         return metrics
+
 
     def _apply_baselines_to_results(self) -> None:
         """Process stored ground truth and compute baseline iterations."""

--- a/src/simpl/simpl.py
+++ b/src/simpl/simpl.py
@@ -175,36 +175,8 @@ class SIMPL:
         # Fitted flag
         self.is_fitted_ = False
 
-        # Device setup
-        gpu_available = jax.default_backend() in ("gpu", "METAL")
-        metal_backend = jax.default_backend() == "METAL"
-        if metal_backend and is_1D_angular and use_gpu is True:
-            warnings.warn(
-                "Angular mode (is_1D_angular=True) requires FFT which is not supported "
-                "on Apple Metal GPU. Falling back to CPU.",
-                stacklevel=2,
-            )
-            self.use_gpu_ = False
-        elif metal_backend and is_1D_angular:
-            self.use_gpu_ = False
-        elif use_gpu is True:
-            if not gpu_available:
-                raise RuntimeError(
-                    "use_gpu=True but no GPU is available. "
-                    "Install a GPU-enabled JAX build or use use_gpu='if_available'."
-                )
-            self.use_gpu_ = True
-        elif use_gpu is False:
-            self.use_gpu_ = False
-        elif use_gpu == "if_available":
-            self.use_gpu_ = gpu_available
-        else:
-            raise ValueError(f"use_gpu must be True, False, or 'if_available', got {use_gpu!r}")
-
-        if self.use_gpu_:
-            self._device_str = f"GPU ({self._jax_gpu_device().device_kind})"
-        else:
-            self._device_str = "CPU"
+        # Device
+        self._setup_device(use_gpu)
 
     # ──────────────────────────────────────────────────────────────────────────
     # Public API
@@ -1595,6 +1567,38 @@ class SIMPL:
     # Internal utilities
     # ──────────────────────────────────────────────────────────────────────────
 
+    def _setup_device(self, use_gpu):
+        """Resolve the ``use_gpu`` parameter and set ``self.use_gpu_`` / ``self._device_str``."""
+        gpu_available = jax.default_backend() in ("gpu", "METAL")
+        metal_backend = jax.default_backend() == "METAL"
+        if metal_backend and self.is_1D_angular and use_gpu is True:
+            warnings.warn(
+                "Angular mode (self.is_1D_angular=True) requires FFT which is not supported "
+                "on Apple Metal GPU. Falling back to CPU.",
+                stacklevel=2,
+            )
+            self.use_gpu_ = False
+        elif metal_backend and self.is_1D_angular:
+            self.use_gpu_ = False
+        elif use_gpu is True:
+            if not gpu_available:
+                raise RuntimeError(
+                    "use_gpu=True but no GPU is available. "
+                    "Install a GPU-enabled JAX build or use use_gpu='if_available'."
+                )
+            self.use_gpu_ = True
+        elif use_gpu is False:
+            self.use_gpu_ = False
+        elif use_gpu == "if_available":
+            self.use_gpu_ = gpu_available
+        else:
+            raise ValueError(f"use_gpu must be True, False, or 'if_available', got {use_gpu!r}")
+
+        if self.use_gpu_:
+            self._device_str = f"GPU ({self._jax_gpu_device().device_kind})"
+        else:
+            self._device_str = "CPU"
+
     @staticmethod
     def _jax_gpu_device():
         """Return the first available GPU/Metal device."""
@@ -1691,7 +1695,7 @@ class SIMPL:
             X=self.results_.mode_l.sel(iteration=1).values, F=self.results_.F.sel(iteration=0).values
         )
         return self._get_loglikelihoods(self.Y_, FX_ML)
-    
+
     def _get_metrics(
         self,
         X: jax.Array | None = None,
@@ -1787,7 +1791,6 @@ class SIMPL:
             metrics["mutual_information"] = utils.calculate_mutual_information(F, PX, self.dt_)
 
         return metrics
-
 
     def _apply_baselines_to_results(self) -> None:
         """Process stored ground truth and compute baseline iterations."""

--- a/src/simpl/simpl.py
+++ b/src/simpl/simpl.py
@@ -1088,7 +1088,7 @@ class SIMPL:
 
         # ── Evaluate and save results ──
         self._evaluate_iteration()
-        ll_data = self._get_loglikelihoods(Y=self.Y_, FX=self.M_["FX"])
+        ll_data = kde.get_ll_and_bps_splits(self.Y_, self.M_["FX"], self.spike_mask_)
         loglikelihoods = _dict_to_dataset(ll_data, self.variable_info_dict_, self.coordinates_dict_).expand_dims(
             {"iteration": [self.iteration_]}
         )
@@ -1595,202 +1595,25 @@ class SIMPL:
             raise ValueError(f"use_gpu must be True, False, or 'if_available', got {use_gpu!r}")
 
         if self.use_gpu_:
-            self._device_str = f"GPU ({self._jax_gpu_device().device_kind})"
+            self._device_str = f"GPU ({self._jax_device().device_kind})"
         else:
             self._device_str = "CPU"
-
-    @staticmethod
-    def _jax_gpu_device():
-        """Return the first available GPU/Metal device."""
-        backend = jax.default_backend()
-        if backend == "METAL":
-            return jax.devices("METAL")[0]
-        return jax.devices("gpu")[0]
 
     def _jax_device(self):
         """Return the JAX device to place arrays on."""
         if self.use_gpu_:
-            return self._jax_gpu_device()
+            backend = jax.default_backend()
+            return jax.devices("METAL" if backend == "METAL" else "gpu")[0]
         return jax.devices("cpu")[0]
 
     def _interpolate_firing_rates(self, X: jax.Array, F: jax.Array) -> jax.Array:
-        """Predict firing rates at arbitrary positions by interpolating the discretised fields.
+        """Nearest-bin lookup of firing rates F at positions X. See ``utils.lookup_firing_rates``."""
+        data = _dict_to_dataset({"F": np.array(F), "X": np.array(X)}, self.variable_info_dict_, self.coordinates_dict_)
+        return utils.lookup_firing_rates(data.F, data.X)
 
-        Given a set of latent positions ``X`` and receptive fields ``F`` (discretised on
-        the environment grid), this method computes the expected firing rate of each neuron
-        at each position using nearest-bin lookup. This is much faster than a full KDE
-        recalculation and is used internally during the M-step to compute ``FX``.
-
-        Parameters
-        ----------
-        X : jnp.ndarray, shape (T, D)
-            Latent positions to interpolate onto.
-        F : jnp.ndarray, shape (N_neurons, N_bins)
-            Receptive fields (place fields) of each neuron, flattened over spatial bins.
-
-        Returns
-        -------
-        FX : jnp.ndarray, shape (T, N_neurons)
-            Estimated firing rate (expected spike count per time bin) of each neuron at
-            each position in ``X``.
-        """
-        F = np.array(F)
-        X = np.array(X)
-        data = _dict_to_dataset({"F": F, "X": X}, self.variable_info_dict_, self.coordinates_dict_)
-        coord_args = {dim: data.X.sel(dim=dim) for dim in self.dim_}
-        FX = data.F.sel(**coord_args, method="nearest").T
-        return FX.data
-
-    def _get_loglikelihoods(self, Y: jax.Array, FX: jax.Array) -> dict:
-        """Calculate log-likelihoods of spikes given firing rates.
-
-        Parameters
-        ----------
-        Y : jnp.ndarray, shape (T, N_neurons)
-            Spike counts.
-        FX : jnp.ndarray, shape (T, N_neurons)
-            Estimated firing rates.
-
-        Returns
-        -------
-        dict
-            Dictionary with 'logPYXF' and 'logPYXF_val' keys.
-        """
-        LLs = {}
-        train_mask = self.spike_mask_
-        val_mask = ~self.spike_mask_
-
-        ll_model_train = kde.poisson_log_likelihood_trajectory(Y, FX, mask=train_mask).sum()
-        ll_model_val = kde.poisson_log_likelihood_trajectory(Y, FX, mask=val_mask).sum()
-        logPYXF = ll_model_train / train_mask.sum()
-        logPYXF_val = ll_model_val / val_mask.sum()
-        LLs["logPYXF"] = logPYXF
-        LLs["logPYXF_val"] = logPYXF_val
-
-        # Bits per spike: (ll_model - ll_mean_rate) / (n_spikes * log2)
-        mean_FX = (Y * train_mask).sum(axis=0, keepdims=True) / train_mask.sum(axis=0, keepdims=True)
-        mean_FX = jnp.broadcast_to(mean_FX, FX.shape)
-
-        ll_model_by_suffix = {"": ll_model_train, "_val": ll_model_val}
-
-        for mask, suffix in [(train_mask, ""), (val_mask, "_val")]:
-            ll_model = ll_model_by_suffix[suffix]
-            ll_baseline = kde.poisson_log_likelihood_trajectory(Y, mean_FX, mask=mask).sum()
-            n_spikes = (Y * mask).sum()
-            bps = jnp.where(n_spikes > 0, (ll_model - ll_baseline) / (n_spikes * jnp.log(2.0)), 0.0)
-            LLs[f"bits_per_spike{suffix}"] = bps
-
-        return LLs
-
-    def _get_ML_loglikelihoods(self) -> dict:
-        """Log-likelihoods for the maximum-likelihood baseline.
-
-        Scores the iteration-1 likelihood mode trajectory (``mode_l``, the
-        per-timebin ML position estimate before any Kalman smoothing) against
-        the iteration-0 receptive fields (built from behavioural positions).
-        Comparing this to iteration-0 metrics isolates the gain from ML
-        decoding alone, before SIMPL's EM refinement of the fields.
-        """
-        FX_ML = self._interpolate_firing_rates(
-            X=self.results_.mode_l.sel(iteration=1).values, F=self.results_.F.sel(iteration=0).values
-        )
-        return self._get_loglikelihoods(self.Y_, FX_ML)
-
-    def _get_metrics(
-        self,
-        X: jax.Array | None = None,
-        F: jax.Array | None = None,
-        Y: jax.Array | None = None,
-        FX: jax.Array | None = None,
-        F_odd_mins: jax.Array | None = None,
-        F_even_mins: jax.Array | None = None,
-        X_prev: jax.Array | None = None,
-        F_prev: jax.Array | None = None,
-        Xt: jax.Array | None = None,
-        Ft: jax.Array | None = None,
-        PX: jax.Array | None = None,
-    ) -> dict:
-        """Calculate metrics on the current iteration's results.
-
-        This is a relaxed function: pass in whatever data you have and it will return
-        whatever metrics it can calculate.
-
-        Parameters
-        ----------
-        X : jnp.ndarray, shape (T, D), optional
-            Estimated latent positions.
-        F : jnp.ndarray, shape (N_neurons, N_bins), optional
-            Estimated place fields.
-        Y : jnp.ndarray, shape (T, N_neurons), optional
-            Spike counts.
-        FX : jnp.ndarray, shape (T, N_neurons), optional
-            Estimated firing rates.
-        F_odd_mins : jnp.ndarray, optional
-            Place fields from odd minutes.
-        F_even_mins : jnp.ndarray, optional
-            Place fields from even minutes.
-        X_prev : jnp.ndarray, optional
-            Latent positions from previous iteration.
-        F_prev : jnp.ndarray, optional
-            Place fields from previous iteration.
-        Xt : jnp.ndarray, optional
-            True latent positions.
-        Ft : jnp.ndarray, optional
-            True place fields.
-        PX : jnp.ndarray, optional
-            Position occupancy.
-
-        Returns
-        -------
-        dict
-            Dictionary of calculated metrics.
-        """
-        metrics = {}
-
-        if Y is not None and FX is not None:
-            LLs = self._get_loglikelihoods(Y, FX)
-            metrics.update(LLs)
-
-        if X is not None and Xt is not None:
-            metrics["X_R2"] = utils.coefficient_of_determination(X, Xt)
-
-        if X is not None and Xt is not None:
-            metrics["X_err"] = jnp.mean(jnp.linalg.norm(X - Xt, axis=1))
-
-        if F is not None and Ft is not None:
-            metrics["F_err"] = jnp.mean(jnp.linalg.norm(F - Ft, axis=1))
-
-        if F is not None:
-            F_pdf = (F + 1e-6) / jnp.sum(F, axis=1)[:, None]
-            I_F = jnp.sum(F_pdf * jnp.log(F_pdf), axis=1)
-            metrics["negative_entropy"] = I_F
-
-        if F is not None:
-            rho_F = jnp.mean(F < 1.0 * self.dt_, axis=1)
-            metrics["sparsity"] = rho_F
-
-        if F_odd_mins is not None and F_even_mins is not None:
-            # Per-neuron Pearson correlation (avoids building a full (2N x 2N) matrix)
-            odd_c = F_odd_mins - jnp.mean(F_odd_mins, axis=1, keepdims=True)
-            even_c = F_even_mins - jnp.mean(F_even_mins, axis=1, keepdims=True)
-            num = jnp.sum(odd_c * even_c, axis=1)
-            denom = jnp.sqrt(jnp.sum(odd_c**2, axis=1) * jnp.sum(even_c**2, axis=1))
-            stability = num / (denom + 1e-12)
-            metrics["stability"] = stability
-
-        if F_prev is not None and F is not None:
-            delta_F = jnp.linalg.norm(F - F_prev, axis=1)
-            metrics["field_change"] = delta_F
-
-        if X_prev is not None and X is not None:
-            delta_X = jnp.linalg.norm(X - X_prev, axis=1)
-            metrics["trajectory_change"] = delta_X
-
-        if F is not None and PX is not None:
-            metrics["spatial_information"] = utils.calculate_spatial_information(F / self.dt_, PX)
-            metrics["mutual_information"] = utils.calculate_mutual_information(F, PX, self.dt_)
-
-        return metrics
+    def _get_metrics(self, **kwargs) -> dict:
+        """Calculate metrics on the current iteration's results. See ``utils.get_iteration_metrics``."""
+        return utils.get_iteration_metrics(spike_mask=self.spike_mask_, dt=self.dt_, **kwargs)
 
     def _apply_baselines_to_results(self) -> None:
         """Process stored ground truth and compute baseline iterations."""

--- a/src/simpl/utils.py
+++ b/src/simpl/utils.py
@@ -14,7 +14,7 @@ Data Preparation
     ``accumulate_spikes``, ``coarsen_dt``, ``create_speckled_mask``
 
 Data I/O
-    ``load_demo_data``, ``print_data_summary``, ``save_results_to_netcdf``,
+    ``load_demo_data``, ``save_results_to_netcdf``,
     ``load_results``, ``rehydrate_model``
 
 Place-Field Analysis
@@ -755,78 +755,6 @@ def load_demo_data(
     return np.load(cached_path)
 
 
-def print_data_summary(data: xr.Dataset) -> None:
-    """Print a concise summary of an ``xr.Dataset`` loaded via ``load_demo_data``.
-
-    Prints the number of neurons, time bins, dimensionality, recording
-    duration, time-bin width, firing-rate statistics (min / Q25 / median /
-    Q75 / max / mean), median speed, mean step size, and the fraction of
-    time bins with 0, 1, or 2+ simultaneously active neurons.
-
-    Parameters
-    ----------
-    data : xr.Dataset
-        Dataset containing at least ``Y`` (spike counts), ``Xb``
-        (behavioural positions), and a ``time`` coordinate."""
-    Y = data.Y.values
-    Xb = data.Xb.values
-    time = data.time.values
-    dt = float(time[1] - time[0])
-    T = len(time)
-    N_neurons = Y.shape[1]
-    D = Xb.shape[1]
-    duration = float(time[-1] - time[0]) + dt
-
-    # Per-neuron firing rates
-    fr_per_neuron = Y.sum(axis=0) / (T * dt)  # (N_neurons,) Hz
-    fr_min = float(np.min(fr_per_neuron))
-    fr_q25 = float(np.percentile(fr_per_neuron, 25))
-    fr_median = float(np.median(fr_per_neuron))
-    fr_q75 = float(np.percentile(fr_per_neuron, 75))
-    fr_max = float(np.max(fr_per_neuron))
-    fr_mean = float(np.mean(fr_per_neuron))
-
-    # Speed and step size
-    step_size = np.linalg.norm(np.diff(Xb, axis=0), axis=1)
-    speed = step_size / dt
-    mean_speed = float(np.median(speed))
-    mean_step = float(np.mean(step_size))
-
-    # Active neurons per bin
-    active = (Y > 0).sum(axis=1)
-    frac_0 = float(np.mean(active == 0))
-    frac_1 = float(np.mean(active == 1))
-    frac_2 = float(np.mean(active == 2))
-    frac_3plus = float(np.mean(active >= 3))
-    max_bar = 30  # max bar width in characters
-    max_frac = max(frac_0, frac_1, frac_2, frac_3plus, 1e-10)
-
-    def bar(frac):
-        return "=" * max(1, int(frac / max_frac * max_bar))
-
-    # Number of trials
-    n_trials = len(data.attrs.get("trial_boundaries", [0]))
-
-    print("DATA SUMMARY:")
-    print(f"  Neurons:    {N_neurons}")
-    print(f"  Dimensions: {D}")
-    print(f"  dt:         {dt:.4f} s")
-    print(f"  Duration:   {duration:.1f} s ({T} bins)")
-    print(f"  Trials:     {n_trials}")
-    print(
-        f"  Neuron firing rate (Hz): mean {fr_mean:.2f}, "
-        f"min {fr_min:.2f}, Q1 {fr_q25:.2f}, "
-        f"median {fr_median:.2f}, Q3 {fr_q75:.2f}, max {fr_max:.2f}"
-    )
-    print(f"  Median speed:     {mean_speed:.3f} m/s")
-    print(f"  Mean distance travelled per dt: {mean_step:.4f} m (may guide your choice of dx)")
-    print("  Simultaneously active neurons per bin:")
-    print(f"    0  {bar(frac_0)} {frac_0:.0%}")
-    print(f"    1  {bar(frac_1)} {frac_1:.0%}")
-    print(f"    2  {bar(frac_2)} {frac_2:.0%}")
-    print(f"    3+ {bar(frac_3plus)} {frac_3plus:.0%}")
-
-
 def save_results_to_netcdf(results: xr.Dataset, path: str) -> None:
     """Save a SIMPL results ``xr.Dataset`` to a netCDF file.
 
@@ -1081,6 +1009,138 @@ def analyse_place_fields(
     }
 
     return place_field_results
+
+
+def get_iteration_metrics(
+    spike_mask: jax.Array,
+    dt: float,
+    X: jax.Array | None = None,
+    F: jax.Array | None = None,
+    Y: jax.Array | None = None,
+    FX: jax.Array | None = None,
+    F_odd_mins: jax.Array | None = None,
+    F_even_mins: jax.Array | None = None,
+    X_prev: jax.Array | None = None,
+    F_prev: jax.Array | None = None,
+    Xt: jax.Array | None = None,
+    Ft: jax.Array | None = None,
+    PX: jax.Array | None = None,
+) -> dict:
+    """Calculate metrics on an iteration's results.
+
+    A relaxed function: pass in whatever data you have and it will return
+    whatever metrics it can calculate.
+
+    Parameters
+    ----------
+    spike_mask : jax.Array, shape (T, N_neurons)
+        Boolean training mask. True = train, False = validation.
+    dt : float
+        Time bin size in seconds.
+    X, F, Y, FX, F_odd_mins, F_even_mins, X_prev, F_prev, Xt, Ft, PX
+        Optional arrays — see ``SIMPL._get_metrics`` for shapes.
+
+    Returns
+    -------
+    dict
+        Dictionary of calculated metrics.
+    """
+    from simpl import kde
+
+    metrics = {}
+
+    if Y is not None and FX is not None:
+        metrics.update(kde.get_ll_and_bps_splits(Y, FX, spike_mask))
+
+    if X is not None and Xt is not None:
+        metrics["X_R2"] = coefficient_of_determination(X, Xt)
+        metrics["X_err"] = jnp.mean(jnp.linalg.norm(X - Xt, axis=1))
+
+    if F is not None and Ft is not None:
+        metrics["F_err"] = jnp.mean(jnp.linalg.norm(F - Ft, axis=1))
+
+    if F is not None:
+        F_pdf = (F + 1e-6) / jnp.sum(F, axis=1)[:, None]
+        metrics["negative_entropy"] = jnp.sum(F_pdf * jnp.log(F_pdf), axis=1)
+        metrics["sparsity"] = jnp.mean(F < 1.0 * dt, axis=1)
+
+    if F_odd_mins is not None and F_even_mins is not None:
+        odd_c = F_odd_mins - jnp.mean(F_odd_mins, axis=1, keepdims=True)
+        even_c = F_even_mins - jnp.mean(F_even_mins, axis=1, keepdims=True)
+        num = jnp.sum(odd_c * even_c, axis=1)
+        denom = jnp.sqrt(jnp.sum(odd_c**2, axis=1) * jnp.sum(even_c**2, axis=1))
+        metrics["stability"] = num / (denom + 1e-12)
+
+    if F_prev is not None and F is not None:
+        metrics["field_change"] = jnp.linalg.norm(F - F_prev, axis=1)
+
+    if X_prev is not None and X is not None:
+        metrics["trajectory_change"] = jnp.linalg.norm(X - X_prev, axis=1)
+
+    if F is not None and PX is not None:
+        metrics["spatial_information"] = calculate_spatial_information(F / dt, PX)
+        metrics["mutual_information"] = calculate_mutual_information(F, PX, dt)
+
+    return metrics
+
+
+def lookup_firing_rates(F: xr.DataArray, X: xr.DataArray) -> np.ndarray:
+    """Nearest-bin lookup of receptive fields F at trajectory positions X.
+
+    Parameters
+    ----------
+    F : xr.DataArray, dims (neuron, *spatial_dims)
+        Receptive fields with spatial coordinates.
+    X : xr.DataArray, dims (time, dim)
+        Trajectory positions. The ``dim`` coordinate must match the spatial
+        dimension names in ``F``.
+
+    Returns
+    -------
+    FX : np.ndarray, shape (T, N_neurons)
+        Firing rate of each neuron at each position.
+    """
+    F_np = xr.DataArray(np.asarray(F.values), dims=F.dims, coords=F.coords)
+    coord_args = {d: xr.DataArray(np.asarray(X.sel(dim=d).values), dims="time") for d in X.dim.values}
+    return np.asarray(F_np.sel(**coord_args, method="nearest").T.values)
+
+
+def get_ML_loglikelihoods(results: xr.Dataset, ignore_silent_bins: bool = False) -> dict[str, float]:
+    """Log-likelihoods for the maximum-likelihood baseline from saved results.
+
+    Scores the iteration-1 likelihood mode trajectory (``mode_l``, the per-timebin
+    ML position estimate before Kalman smoothing) against the iteration-0 receptive
+    fields (built from behavioural positions). This isolates the gain from ML
+    decoding alone, before SIMPL's EM refinement.
+
+    Parameters
+    ----------
+    results : xr.Dataset
+        A SIMPL results dataset containing ``F``, ``mode_l``, ``Y``, and
+        ``spike_mask`` with an ``iteration`` coordinate.
+    ignore_silent_bins : bool
+        If True, exclude time bins where no neuron fired (total spike count = 0).
+        The ML position estimate is uninformative in these bins.
+
+    Returns
+    -------
+    dict
+        Keys: ``logPYXF``, ``logPYXF_val``, ``bits_per_spike``, ``bits_per_spike_val``.
+    """
+    from simpl import kde
+
+    F = results["F"].sel(iteration=0)
+    X = results["mode_l"].sel(iteration=1)
+    FX = jnp.array(lookup_firing_rates(F, X))
+
+    Y = jnp.array(results["Y"].values)
+    spike_mask = jnp.array(results["spike_mask"].values, dtype=bool)
+
+    if ignore_silent_bins:
+        has_spikes = Y.sum(axis=1) > 0  # (T,)
+        spike_mask = spike_mask & has_spikes[:, None]
+
+    return kde.get_ll_and_bps_splits(Y, FX, spike_mask)
 
 
 def calculate_spatial_information(

--- a/tests/test_kde.py
+++ b/tests/test_kde.py
@@ -9,7 +9,7 @@ from simpl.kde import (
     kde,
     kde_angular,
     poisson_log_likelihood,
-    poisson_log_likelihood_trajectory,
+    poisson_log_likelihood_maps,
 )
 
 
@@ -108,12 +108,12 @@ class TestKDEAngular:
         assert jnp.all(jnp.isfinite(result))
 
 
-class TestPoissonLogLikelihood:
+class TestPoissonLogLikelihoodMaps:
     def test_correct_shape(self):
         T, N_neurons, N_bins = 50, 5, 20
         spikes = jnp.ones((T, N_neurons), dtype=jnp.int32)
         mean_rate = jnp.ones((N_neurons, N_bins)) * 0.1
-        result = poisson_log_likelihood(spikes, mean_rate)
+        result = poisson_log_likelihood_maps(spikes, mean_rate)
         assert result.shape == (T, N_bins)
 
     @pytest.mark.cpu_only
@@ -125,28 +125,31 @@ class TestPoissonLogLikelihood:
         mean_rate = jnp.array(np.random.uniform(0.01, 0.5, (N_neurons, N_bins)))
         mask = jnp.ones((T, N_neurons), dtype=bool)
         mask_half = mask.at[:, :2].set(False)
-        result_full = poisson_log_likelihood(spikes, mean_rate, mask=mask)
-        result_masked = poisson_log_likelihood(spikes, mean_rate, mask=mask_half)
+        result_full = poisson_log_likelihood_maps(spikes, mean_rate, mask=mask)
+        result_masked = poisson_log_likelihood_maps(spikes, mean_rate, mask=mask_half)
         # Results should differ when mask changes
         assert not jnp.allclose(result_full, result_masked)
 
 
-class TestPoissonLogLikelihoodTrajectory:
+class TestPoissonLogLikelihood:
     def test_correct_shape(self):
         T, N_neurons = 50, 5
         spikes = jnp.ones((T, N_neurons), dtype=jnp.int32)
-        mean_rate = jnp.ones((T, N_neurons)) * 0.1
-        result = poisson_log_likelihood_trajectory(spikes, mean_rate)
-        assert result.shape == (T,)
+        rates = jnp.ones((T, N_neurons)) * 0.1
+        result = poisson_log_likelihood(spikes, rates)
+        assert result.shape == (T, N_neurons)
 
-    @pytest.mark.cpu_only
-    def test_masking(self):
+    def test_arbitrary_shape(self):
+        spikes = jnp.ones((3, 4, 5), dtype=jnp.int32)
+        rates = jnp.ones((3, 4, 5)) * 0.1
+        result = poisson_log_likelihood(spikes, rates)
+        assert result.shape == (3, 4, 5)
+
+    def test_masking_downstream(self):
         np.random.seed(42)
         T, N_neurons = 50, 5
         spikes = jnp.array(np.random.randint(0, 3, (T, N_neurons)))
-        mean_rate = jnp.array(np.random.uniform(0.01, 0.5, (T, N_neurons)))
-        mask = jnp.ones((T, N_neurons), dtype=bool)
-        mask_half = mask.at[:, :2].set(False)
-        result_full = poisson_log_likelihood_trajectory(spikes, mean_rate, mask=mask)
-        result_masked = poisson_log_likelihood_trajectory(spikes, mean_rate, mask=mask_half)
-        assert not jnp.allclose(result_full, result_masked)
+        rates = jnp.array(np.random.uniform(0.01, 0.5, (T, N_neurons)))
+        ll = poisson_log_likelihood(spikes, rates)
+        mask = jnp.ones((T, N_neurons), dtype=bool).at[:, :2].set(False)
+        assert not jnp.allclose(ll.sum(), (ll * mask).sum())

--- a/tests/test_simpl.py
+++ b/tests/test_simpl.py
@@ -373,8 +373,10 @@ class TestSIMPLInterpolateFiringRates:
 
 class TestSIMPLGetLoglikelihoods:
     def test_expected_keys(self, small_simpl_model):
+        from simpl import kde
+
         model = small_simpl_model
-        lls = model._get_loglikelihoods(model.Y_, model.M_["FX"])
+        lls = kde.get_ll_and_bps_splits(model.Y_, model.M_["FX"], model.spike_mask_)
         assert "logPYXF" in lls
         assert "logPYXF_val" in lls
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -27,7 +27,6 @@ from simpl.utils import (
     load_demo_data,
     load_results,
     log_gaussian_pdf,
-    print_data_summary,
     save_results_to_netcdf,
 )
 
@@ -443,29 +442,6 @@ class TestAccumulateSpikes:
         Y = self._make_Y()
         result = accumulate_spikes(Y, window=3)
         assert result.dtype == Y.dtype
-
-
-class TestPrintDataSummary:
-    def test_prints_output(self, demo_data, capsys):
-        """print_data_summary should produce output with key headings."""
-        Y = demo_data["Y"][:500]
-        Xb = demo_data["Xb"][:500]
-        time = demo_data["time"][:500]
-        data = xr.Dataset(
-            {
-                "Y": xr.DataArray(Y, dims=["time", "neuron"], coords={"time": time}),
-                "Xb": xr.DataArray(Xb, dims=["time", "dim"], coords={"time": time}),
-            }
-        )
-        data.attrs["trial_boundaries"] = np.array([0])
-        print_data_summary(data)
-        captured = capsys.readouterr().out
-        assert "DATA SUMMARY" in captured
-        assert "Neurons" in captured
-        assert "Dimensions" in captured
-        assert "dt" in captured
-        assert "Neuron firing rate" in captured
-        assert "Simultaneously active neurons per bin" in captured
 
 
 @pytest.mark.cpu_only


### PR DESCRIPTION
# Refactor: extract reusable utilities from SIMPL class, clean up kde.py, add ML baseline

## Summary

Refactors computation out of the SIMPL class into standalone utilities in `kde.py` and `utils.py`, and adds a new ML baseline comparison that can be computed directly from saved results.

### kde.py — cleaner Poisson log-likelihood API

- **`poisson_log_likelihood(spikes, rates)`**: Per-element LL, any shape, no mask (the clean primitive). Replaces both the old `poisson_log_likelihood` and `poisson_log_likelihood_trajectory`.
- **`poisson_log_likelihood_maps(spikes, mean_rate, mask)`**: Matmul-based spatial broadcast for the E-step. Renormalization removed from function signature — done inline in `decode_observations` where needed.
- **`get_ll_and_bps_splits(Y, FX, mask)`**: Train/val log-likelihood and bits-per-spike, extracted from `SIMPL._get_loglikelihoods` (now deleted). Returns plain Python floats.
- **`_log_factorial_stirling`**: Shared Stirling approximation helper, deduplicating the computation between the two LL functions.

### utils.py — new post-hoc analysis utilities

- **`get_ML_loglikelihoods(results, ignore_silent_bins=True)`**: Compute the naive ML baseline (F@iter0 scored on mode_l@iter1) directly from a saved `results_` Dataset. No fitted SIMPL instance needed. `ignore_silent_bins` excludes time bins with zero spikes, where the ML position estimate is uninformative.
- **`lookup_firing_rates(F, X)`**: Nearest-bin xarray interpolation of receptive fields at trajectory positions. Shared by `SIMPL._interpolate_firing_rates` and `get_ML_loglikelihoods`.
- **`get_iteration_metrics(spike_mask, dt, ...)`**: All per-iteration metric computation (LL, R², errors, entropy, sparsity, stability, spatial/mutual info) extracted from `SIMPL._get_metrics` (~95 lines moved out of the class).

### simpl.py — slimmed down

- `_get_loglikelihoods` deleted — call sites use `kde.get_ll_and_bps_splits` directly.
- `_get_metrics` is now a one-liner delegating to `utils.get_iteration_metrics`.
- `_get_ML_loglikelihoods` delegates to `utils.get_ML_loglikelihoods`.
- `_interpolate_firing_rates` delegates to `utils.lookup_firing_rates`.
- Device setup moved to `_setup_device()`, `_jax_gpu_device` merged into `_jax_device`.

### plotting.py — ML baseline lines

- `plot_fitting_summary` and `plot_all_metrics` now show dotted horizontal lines for the naive ML baseline (val) on bits-per-spike and logPYXF panels, with text labels anchored at the left edge.
- Ground truth baseline lines (when present) also get text labels.

### Removed

- `print_data_summary` (unused outside tests).

## Motivation

The SIMPL class had accumulated computation that didn't depend on instance state. This made post-hoc analysis from saved results impossible without a fitted model. The refactor enables:
- Computing log-likelihoods, metrics, and ML baselines from saved `xr.Dataset` results
- Clean, composable Poisson LL primitives
- Visual comparison of SIMPL vs naive ML on diagnostic plots



====


Original PR is here https://github.com/TomGeorge1234/SIMPL/pull/85.

I realized that we don't need to rehydrate the entire model to calculate log-likelihoods for an arbitrary pair of trajectory and tuning curves.

This PR only adds some functions in `utils.py`. 
Since we believe that benchmarking should at least include
- Behavioral trajectory + tuning curve from behavior
- Maximum likelihood decoding trajectory + tuning curve from behavior
, there is a dedicated function for this `compare_SIMPL_vs_baseline_vs_ML`
https://github.com/TomGeorge1234/SIMPL/blob/0b6dc54fbb1ce65217f2d5a91238f2700bd72ec5/src/simpl/utils.py#L1071

Using this is very easy. 

```
from simpl.utils import load_results, compare_SIMPL_vs_baseline_vs_ML

results = load_results(file_path)
comparison = compare_SIMPL_vs_baseline_vs_ML(results)
```