### PR TITLE
Reduce memory duplication

### DIFF
--- a/src/simpl/kde.py
+++ b/src/simpl/kde.py
@@ -275,8 +275,17 @@ def get_ll_and_bps_splits(
     Y: jax.Array,
     FX: jax.Array,
     mask: jax.Array,
+    batch_size: int | None = None,
 ) -> dict:
     """Compute train/val log-likelihoods and bits-per-spike from spikes and predicted rates.
+
+    The whole computation reduces to four scalars, so it is streamed over the time axis in
+    a single batched pass: each batch contributes running sums (accumulated via ``tree.map``)
+    and the full ``(T, N_neurons)`` per-bin log-likelihood / ``~mask`` temporaries are never
+    materialised at once, keeping peak memory at ``O(batch_size * N_neurons)`` rather than
+    ``O(T * N_neurons)``. The constant-rate baseline log-likelihood has a closed form in the
+    per-neuron train/val spike sums, bin counts and log-factorial sums, so it needs no second
+    pass: ``Σ_t mask·[Y·log(μ+ε) − μ − log Y!] = log(μ+ε)·Σ(Y) − μ·Σ(mask) − Σ(log Y!)``.
 
     Parameters
     ----------
@@ -286,31 +295,57 @@ def get_ll_and_bps_splits(
         Predicted firing rates (expected spikes per time bin).
     mask : jax.Array, shape (T, N_neurons)
         Boolean training mask. True = train, False = validation.
+    batch_size : int or None
+        Number of time bins per batch. If None (default), chosen from
+        ``MAX_BATCH_ELEMENTS`` to target a small peak working set.
 
     Returns
     -------
     dict
         Keys: ``logPYXF``, ``logPYXF_val``, ``bits_per_spike``, ``bits_per_spike_val``.
     """
-    val_mask = ~mask
-    ll = poisson_log_likelihood(Y, FX)
+    T, N = Y.shape
+    if batch_size is None:
+        from simpl import MAX_BATCH_ELEMENTS
 
-    ll_train = (ll * mask).sum()
-    ll_val = (ll * val_mask).sum()
+        batch_size = max(256, MAX_BATCH_ELEMENTS // max(N, 1))
+    batch_size = min(batch_size, T)
 
-    mean_FX = (Y * mask).sum(axis=0, keepdims=True) / mask.sum(axis=0, keepdims=True)
-    mean_FX = jnp.broadcast_to(mean_FX, FX.shape)
-    ll_baseline = poisson_log_likelihood(Y, mean_FX)
+    @jax.jit
+    def _batch_sums(Y_b, FX_b, mask_b):
+        """Per-batch partial sums for both splits (suffix 0 = train, 1 = val)."""
+        log_fact = _log_factorial_stirling(Y_b)
+        ll = poisson_log_likelihood(Y_b, FX_b)  # model per-bin log-likelihood
+        out = {}
+        for s, m in (("0", mask_b), ("1", ~mask_b)):
+            out[f"ll{s}"] = (ll * m).sum()  # scalar model log-likelihood
+            out[f"spikes{s}"] = (Y_b * m).sum(axis=0)  # (N,) spike sum per neuron
+            out[f"bins{s}"] = m.sum(axis=0)  # (N,) bin count per neuron
+            out[f"logfact{s}"] = (log_fact * m).sum(axis=0)  # (N,) Σ log Y! per neuron
+        return out
+
+    def _sums(start):
+        end = min(start + batch_size, T)
+        return _batch_sums(Y[start:end], FX[start:end], mask[start:end])
+
+    acc = _sums(0)  # initialise with the first batch, then accumulate the rest
+    for start in range(batch_size, T, batch_size):
+        acc = jax.tree.map(jnp.add, acc, _sums(start))
+
+    def _bps(split):
+        """Bits-per-spike for one split from its accumulated per-neuron sums."""
+        spikes, bins, logfact = acc[f"spikes{split}"], acc[f"bins{split}"], acc[f"logfact{split}"]
+        mu = acc["spikes0"] / acc["bins0"]  # baseline rate = train mean (used for both splits)
+        ll_base = jnp.sum(jnp.log(mu + 1e-3) * spikes - mu * bins - logfact)
+        n_spikes = spikes.sum()
+        return jnp.where(n_spikes > 0, (acc[f"ll{split}"] - ll_base) / (n_spikes * jnp.log(2.0)), 0.0)
 
     LLs = {
-        "logPYXF": ll_train / mask.sum(),
-        "logPYXF_val": ll_val / val_mask.sum(),
+        "logPYXF": acc["ll0"] / acc["bins0"].sum(),
+        "logPYXF_val": acc["ll1"] / acc["bins1"].sum(),
+        "bits_per_spike": _bps("0"),
+        "bits_per_spike_val": _bps("1"),
     }
-    for m, suffix, ll_model in [(mask, "", ll_train), (val_mask, "_val", ll_val)]:
-        ll_base = (ll_baseline * m).sum()
-        n_spikes = (Y * m).sum()
-        LLs[f"bits_per_spike{suffix}"] = jnp.where(n_spikes > 0, (ll_model - ll_base) / (n_spikes * jnp.log(2.0)), 0.0)
-
     return {k: float(v) for k, v in LLs.items()}
 
 

--- a/src/simpl/simpl.py
+++ b/src/simpl/simpl.py
@@ -1105,8 +1105,11 @@ class SIMPL:
         self.M_ = self._M_step(Y=self.Y_, X=X)
 
         # ── Evaluate and save results ──
-        self._evaluate_iteration()
+        # Compute the streamed train/val log-likelihood scalars once and reuse them for both
+        # the loglikelihoods_ table and the per-iteration results dataset (avoids a second
+        # full O(T·N) metrics pass).
         ll_data = kde.get_ll_and_bps_splits(self.Y_, self.M_["FX"], self.spike_mask_)
+        self._evaluate_iteration(ll_data)
         loglikelihoods = _dict_to_dataset(ll_data, self.variable_info_dict_, self.coordinates_dict_).expand_dims(
             {"iteration": [self.iteration_]}
         )
@@ -1124,18 +1127,25 @@ class SIMPL:
         self.X_ = self.E_["X"]
         self.F_ = self.M_["F"].reshape(self.N_neurons_, *self.xF_shape_)
 
-    def _evaluate_iteration(self) -> None:
+    def _evaluate_iteration(self, ll_data: dict) -> None:
         """Evaluate the current iteration's metrics and append to the results Dataset.
 
         Computes log-likelihoods, spatial information, stability, place field analysis,
         and (if ground truth is available) R², trajectory error, and field error. The
         results are stored under the current iteration in ``self.results_``.
+
+        Parameters
+        ----------
+        ll_data : dict
+            Pre-computed train/val log-likelihood scalars (``logPYXF``, ``bits_per_spike``,
+            …) from ``kde.get_ll_and_bps_splits``. Passed in (rather than recomputed here
+            from the full ``(T, N)`` ``FX``) so the streamed log-likelihood pass runs once.
         """
         evals = self._get_metrics(
             X=self.E_["X"],
             F=self.M_["F"],
-            Y=self.Y_,
-            FX=self.M_["FX"],
+            Y=None,  # log-likelihoods are supplied via ll_data; skip the recompute in _get_metrics
+            FX=None,
             F_odd_mins=self.M_.get("F_odd_minutes"),
             F_even_mins=self.M_.get("F_even_minutes"),
             X_prev=self.lastX_,
@@ -1144,7 +1154,7 @@ class SIMPL:
             Ft=self.Ft_,
             PX=self.M_["PX"],
         )
-        iteration_data = {**self.M_, **self.E_, **evals}
+        iteration_data = {**self.M_, **self.E_, **evals, **ll_data}
         if not self.save_full_history_:
             iteration_data.pop("FX", None)
         iteration_data.pop("logPYXF_maps", None)

--- a/src/simpl/simpl.py
+++ b/src/simpl/simpl.py
@@ -48,6 +48,7 @@ class SIMPL:
         val_frac: float = 0.1,
         speckle_block_size_seconds: float = 1,
         random_seed: int = 0,
+        compute_stability: bool = False,
         # Device
         use_gpu: bool | str = "if_available",
     ) -> None:
@@ -141,6 +142,13 @@ class SIMPL:
         random_seed : int, optional
             Random seed for reproducibility (controls the spike mask generation).
             By default 0.
+        compute_stability : bool, optional
+            Whether to compute the split-half ``stability`` metric (correlation between
+            receptive fields fitted on odd- vs even-minute data). This requires fitting two
+            extra sets of receptive fields per iteration and materialising two additional
+            ``(T, N_neurons)`` boolean masks, so it is disabled by default to save time and
+            memory on large datasets. When False, the ``stability`` metric is absent from
+            ``results_``. By default False.
         use_gpu : bool or str, optional
             Controls GPU usage. ``True`` forces GPU and raises an error if none is
             available. ``False`` forces CPU even when a GPU is present.
@@ -171,6 +179,7 @@ class SIMPL:
         self.val_frac = val_frac
         self.speckle_block_size_seconds = speckle_block_size_seconds
         self.random_seed = random_seed
+        self.compute_stability = compute_stability
 
         # Fitted flag
         self.is_fitted_ = False
@@ -943,12 +952,19 @@ class SIMPL:
             )
 
         self._substatus("E✓·M  tuning curves")
-        stacked_masks = jnp.array([self.spike_mask_, self.odd_minute_mask_, self.even_minute_mask_])
-        all_F, all_PX = vmap(kde_func)(stacked_masks)
-        F, F_odd_minutes, F_even_minutes = all_F[0], all_F[1], all_F[2]
-        PX = all_PX[0]
+        if self.compute_stability:
+            # Fit fields on the train mask plus the odd/even-minute splits in one vmap.
+            stacked_masks = jnp.array([self.spike_mask_, self.odd_minute_mask_, self.even_minute_mask_])
+            all_F, all_PX = vmap(kde_func)(stacked_masks)
+            F, F_odd_minutes, F_even_minutes = all_F[0], all_F[1], all_F[2]
+            PX = all_PX[0]
+        else:
+            F, PX = kde_func(self.spike_mask_)
         FX = self._interpolate_firing_rates(X, F)
-        M = {"F": F, "F_odd_minutes": F_odd_minutes, "F_even_minutes": F_even_minutes, "FX": FX, "PX": PX}
+        M = {"F": F, "FX": FX, "PX": PX}
+        if self.compute_stability:
+            M["F_odd_minutes"] = F_odd_minutes
+            M["F_even_minutes"] = F_even_minutes
         return M
 
     def _decode(
@@ -1120,8 +1136,8 @@ class SIMPL:
             F=self.M_["F"],
             Y=self.Y_,
             FX=self.M_["FX"],
-            F_odd_mins=self.M_["F_odd_minutes"],
-            F_even_mins=self.M_["F_even_minutes"],
+            F_odd_mins=self.M_.get("F_odd_minutes"),
+            F_even_mins=self.M_.get("F_even_minutes"),
             X_prev=self.lastX_,
             F_prev=self.lastF_,
             Xt=self.Xt_,
@@ -1402,8 +1418,14 @@ class SIMPL:
                     "Adjust val_frac or speckle_block_size_seconds."
                 )
 
-        self.odd_minute_mask_ = jnp.stack([jnp.array(self.time_ // 60 % 2 == 0)] * self.N_neurons_, axis=1)
-        self.even_minute_mask_ = ~self.odd_minute_mask_
+        # Odd/even-minute masks are only needed for the split-half stability metric.
+        if self.compute_stability:
+            odd = (self.time_ // 60 % 2 == 0)[:, None]
+            self.odd_minute_mask_ = jnp.broadcast_to(odd, (self.T_, self.N_neurons_))
+            self.even_minute_mask_ = ~self.odd_minute_mask_
+        else:
+            self.odd_minute_mask_ = None
+            self.even_minute_mask_ = None
 
         if align_to_behavior is True:
             align_to_behavior = "trajectory"
@@ -1817,6 +1839,7 @@ class SIMPL:
             "speckle_block_size_seconds": self.speckle_block_size_seconds,
             "save_full_history": int(getattr(self, "save_full_history_", False)),
             "random_seed": self.random_seed,
+            "compute_stability": int(self.compute_stability),
             "use_gpu": int(self.use_gpu_),
         }
 

--- a/src/simpl/simpl.py
+++ b/src/simpl/simpl.py
@@ -1200,8 +1200,9 @@ class SIMPL:
 
             # Warnings
             mi_rate = float(np.array(self.results_.mutual_information.sel(iteration=0)).sum())
-            active_per_bin = (np.array(self.Y_) > 0).sum(axis=1)
-            frac_2plus = float(np.mean(active_per_bin >= 2))
+            # Compute on-device to avoid copying the full (T, N) matrix back to host.
+            active_per_bin = (self.Y_ > 0).sum(axis=1)
+            frac_2plus = float(jnp.mean(active_per_bin >= 2))
             if frac_2plus < 0.05:
                 print("  ⚠ fewer than 5% of time bins have 2+ active neurons. Try coarsen_dt() or add more neurons.")
             if mi_rate < 1.0:
@@ -1307,7 +1308,9 @@ class SIMPL:
         # ── Convert data to JAX arrays (on the chosen device) ──
         neurons = np.arange(self.N_neurons_)
         device = self._jax_device()
-        self.Y_ = jax.device_put(jnp.array(Y), device)
+        # device_put a float32 view directly: np.asarray is a no-op when Y is already
+        # float32, avoiding an extra full (T, N) host copy from jnp.array(Y).
+        self.Y_ = jax.device_put(np.asarray(Y, dtype=np.float32), device)
         self.Xb_ = jax.device_put(jnp.array(Xb), device)
         self.time_ = jax.device_put(jnp.array(time), device)
         self.neuron_ = jax.device_put(jnp.array(neurons), device)
@@ -1392,7 +1395,7 @@ class SIMPL:
                 block_size=self.block_size_,
                 random_seed=self.random_seed,
             )
-            n_train = int(np.asarray(self.spike_mask_).sum())
+            n_train = int(jnp.sum(self.spike_mask_))
             if n_train == 0:
                 raise ValueError(
                     "The held-out mask produced an empty train split (no spikes are used for fitting). "
@@ -1510,7 +1513,7 @@ class SIMPL:
         env = self.environment_
         duration = float(self.time_[-1] - self.time_[0]) + self.dt_
         grid_str = "x".join(str(s) for s in env.discrete_env_shape)
-        total_spikes = int(np.array(self.Y_).sum())
+        total_spikes = int(jnp.sum(self.Y_))
         spike_str = (
             f"{total_spikes / 1_000_000:.1f}M"
             if total_spikes >= 1_000_000
@@ -1519,7 +1522,7 @@ class SIMPL:
             else str(total_spikes)
         )
         mean_fr = total_spikes / duration / self.N_neurons_
-        empty_frac = float(np.mean(np.array(self.Y_).sum(axis=1) == 0)) * 100
+        empty_frac = float(jnp.mean(jnp.sum(self.Y_, axis=1) == 0)) * 100
         n_trials = len(self.trial_boundaries_)
         line1 = [
             f"{self.N_neurons_} neurons",

--- a/src/simpl/utils.py
+++ b/src/simpl/utils.py
@@ -557,7 +557,6 @@ def create_speckled_mask(
     random_seed: int = 0,
 ) -> jax.Array:
     """
-    TODO : Rewrite this in JAX
     Creates a boolean mask of size `size`. This mask is all True except along each column randomly
     there are contiguous blocks of False of length `block_size`. Overall ~`sparsity`
     of the mask is False. For example, if sparsity is 0.3, block size is 3 and size is
@@ -579,8 +578,19 @@ def create_speckled_mask(
 
     Returns
     -------
-    mask : np.ndarray
-        A boolean mask with the specified properties.
+    mask : jax.Array
+        A boolean mask with the specified properties, built on the default JAX device.
+
+    Notes
+    -----
+    Each column's False blocks are laid down vectorised, without a per-element Python loop:
+    for a chunk of columns, +1/-1 markers are scattered at every block's start/end into a
+    delta array, and a cumulative sum along time recovers the per-bin "inside a block"
+    count (``> 0`` ⇒ held out). Overlapping blocks within a column are handled naturally
+    by the running count. Columns are processed in chunks sized by ``MAX_BATCH_ELEMENTS``
+    so the transient integer delta array stays bounded, and each chunk is written into a
+    single pre-allocated boolean array; the result is moved to the default JAX device in
+    one (zero-copy, on CPU) ``device_put``.
     """
     if len(size) != 2 or size[0] <= 0 or size[1] <= 0:
         raise ValueError(f"size must be a pair of positive integers, got {size}")
@@ -595,16 +605,31 @@ def create_speckled_mask(
             f"block_size must be smaller than the time dimension so the mask leaves training data, got {block_size}"
         )
 
-    mask = np.ones(size, dtype=bool)
-    num_blocks_per_row = int(sparsity * size[0] / block_size)
-    np.random.seed(random_seed)
-    for row in range(size[1]):
-        for block in range(num_blocks_per_row):
-            # Randomly choose starting positions within the bounds
-            start_idx = np.random.randint(0, size[0] - block_size)
-            end_idx = min(start_idx + block_size, size[0])
-            mask[start_idx:end_idx, row] = False
-    return jnp.array(mask)
+    from simpl import MAX_BATCH_ELEMENTS
+
+    T, N = size
+    num_blocks_per_row = int(sparsity * T / block_size)
+    if num_blocks_per_row == 0:
+        return jnp.ones(size, dtype=bool)
+
+    # One random start index per (column, block); start in [0, T - block_size) so each
+    # block of length block_size fits within the time axis.
+    starts = random.randint(random.PRNGKey(random_seed), (N, num_blocks_per_row), 0, T - block_size)
+
+    # Process columns in chunks so the transient integer delta array stays bounded. Each
+    # chunk is written straight into one pre-allocated boolean array (no host+device
+    # boolean duplication); a single device_put moves the result to the JAX device.
+    col_chunk = max(1, min(N, MAX_BATCH_ELEMENTS // (T + 1)))
+    mask = np.empty((T, N), dtype=bool)
+    for c0 in range(0, N, col_chunk):
+        s = starts[c0 : c0 + col_chunk]  # (c, num_blocks)
+        c = s.shape[0]
+        col_ix = jnp.broadcast_to(jnp.arange(c)[:, None], (c, num_blocks_per_row))
+        # +1 at each block start, -1 one past each block end; cumsum gives the per-bin
+        # count of overlapping held-out blocks.
+        delta = jnp.zeros((T + 1, c), dtype=jnp.int32).at[s, col_ix].add(1).at[s + block_size, col_ix].add(-1)
+        mask[:, c0 : c0 + c] = np.asarray(jnp.cumsum(delta[:-1], axis=0) <= 0)
+    return jax.device_put(mask)
 
 
 def find_time_jumps(


### PR DESCRIPTION
SIMPL quietly duplicated the (T, N) spike matrix in many forms throughout initialisation. This hardly ever matter except at the memory limit where either was highly inefficient to have many large matrices hanging around when they could be avoided. 

This cleans it up, reduces duplication. It also vectorises the create_mask function which was becoming a time-bottleneck for very very large input matrices. 

With this I have been able to scale SIMPL to 30,000 neurons x 100,000 time bins. Thats _about_ 3 billion spikes and now sits around the level of the biggest single-session neural datasets which currently exist. I think we are very close tot he theoretical limit on a single CPU now.