### PR TITLE
Fix CCA bug and remove version pin

### DIFF
--- a/src/simpl/utils.py
+++ b/src/simpl/utils.py
@@ -332,8 +332,9 @@ def cca(X: jax.Array, Y: jax.Array) -> tuple[np.ndarray, np.ndarray]:
 
     cca = sklearn.cross_decomposition.CCA(n_components=D, max_iter=2000)
     cca.fit(X, Y)
-    coef = cca.coef_  # / cca._x_std # this randomly changed at some point
-    intercept = cca.intercept_ - cca._x_mean @ coef.T
+    origin = np.zeros((1, D))
+    intercept = cca.predict(origin)[0]
+    coef = (cca.predict(np.eye(D)) - intercept).T
     return coef, intercept
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -155,6 +155,18 @@ class TestCCA:
         X_pred = X @ coef.T + intercept
         assert jnp.allclose(X, X_pred, atol=0.1)
 
+    def test_scaled_feature_mapping(self):
+        rng = np.random.default_rng(42)
+        X = rng.normal(size=(200, 2)) * np.array([10.0, 0.2]) + np.array([5.0, -3.0])
+        true_coef = np.array([[0.7, -0.2], [0.1, 1.4]])
+        true_intercept = np.array([2.0, -1.0])
+        Y = X @ true_coef.T + true_intercept
+
+        coef, intercept = cca(jnp.array(X), jnp.array(Y))
+        Y_pred = X @ coef.T + intercept
+
+        assert np.sqrt(np.mean((Y - Y_pred) ** 2)) < 1.0
+
 
 class TestCorrelationAtLag:
     def test_autocorrelation_lag_zero(self):


### PR DESCRIPTION
SIMPL only worked with sklearn >= 1.5.0 as pointed out by @colleenjg in #114 

This was because sklearn disruptively changed the inner workings of its CCA function from 

```  
# 1.3.1
self.coef_ = (self.coef_ * self._y_std).T

# to this:

# 1.5.0
self.coef_ = (self.coef_ * self._y_std).T / self._x_std
```

Since we directly we using self.coef_ in our alignment step that broke. I rejigged the alignment step to not use these hidden variables and now it works in both versions. I have subsequently removed the sklearn version pin entirely. 