### PR TITLE
Revamp how speed_prior controls if kalman smoothing occurs

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ $$
 {\color{1D5C84}\mathcal{N}\!\left(X_t; X_{t-\Delta t}, (\sigma_v\,\Delta t)^2 I\right)}
 $$
 
+Smaller `speed_prior` values enforce smoother decoded trajectories; larger values let each time bin follow the spike likelihood more freely. Set `speed_prior=None` to strictly disable Kalman smoothing entirely.
+
 **Optional (`behavior_prior`)**  
 SIMPL can also include a soft Gaussian tether to whatever the latent was initialised to (typically behavior), controlled by $\sigma_b$ (`behavior_prior`):
 
@@ -175,6 +177,8 @@ $$
 \,
 \cdot \underbrace{{\color{A3CC90}\mathcal{N}\!\left(X_t; X_t^{(0)}, \sigma_b^2 I\right)}}_{{\color{A3CC90}\mathrm{latent\ close\ to\ initialisation}}}
 $$
+
+Smaller `behavior_prior` values enforce decoded trajectory to be closer to the behavior passed into `Xb`; larger values let each time bin follow the spike likelihood more freely (potentially moving far from behavior). Set `behavior_prior=None` to strictly disable behavior tether.
 
 Once fields are estimated an approximation (see paper) converts Poisson-nonlinear observations to linear observations, allowing these dynamics to be inferred with fast Kalman smoothing.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,8 @@ dependencies = [
     "scikit-image",
     "matplotlib",
     "netcdf4",
+    "h5netcdf",
+    "h5py",
 ]
 
 [project.scripts]

--- a/src/simpl/simpl.py
+++ b/src/simpl/simpl.py
@@ -35,8 +35,7 @@ class SIMPL:
         self,
         # Model hyperparameters
         kernel_bandwidth: float = 0.02,
-        speed_prior: float = 0.1,
-        use_kalman_smoothing: bool = True,
+        speed_prior: float | None = 0.1,
         behavior_prior: float | None = None,
         # Environment parameters
         is_1D_angular: bool = False,
@@ -92,15 +91,13 @@ class SIMPL:
             The bandwidth of the Gaussian kernel (in the same units as the latent space, e.g.
             meters) used for KDE when fitting receptive fields. Smaller values give sharper
             fields but are noisier; larger values smooth more. By default 0.02.
-        speed_prior : float, optional
+        speed_prior : float or None, optional
             Prior on agent speed in units of meters per second. This controls the strength of
             the Kalman smoother: a low speed prior constrains the decoded trajectory to be
             smooth, while a high value lets the trajectory follow the spike likelihood more
-            closely. By default 0.1 m/s.
-        use_kalman_smoothing : bool, optional
-            Whether to use Kalman smoothing dynamics in the E-step. If False, the speed prior
-            is set very high, effectively disabling temporal smoothing and letting the
-            trajectory follow the per-bin maximum-likelihood estimate. By default True.
+            closely. Set to None to disable Kalman smoothing and let the trajectory follow
+            the per-bin maximum-likelihood estimate independently in each time bin. By default
+            0.1 m/s.
         behavior_prior : float or None, optional
             Prior on how far the latent positions can deviate from the behavioral positions,
             in units of meters. This acts as a soft constraint pulling the decoded trajectory
@@ -165,7 +162,6 @@ class SIMPL:
         # Model hyperparameters
         self.kernel_bandwidth = kernel_bandwidth
         self.speed_prior = speed_prior
-        self.use_kalman_smoothing = use_kalman_smoothing
         self.behavior_prior = behavior_prior
         self.is_1D_angular = is_1D_angular
 
@@ -1270,7 +1266,7 @@ class SIMPL:
             raise ValueError("time must be strictly increasing")
         dt_median = np.median(dt)
         if (
-            self.use_kalman_smoothing
+            self.speed_prior is not None
             and dt_median > 0
             and np.max(np.abs(dt - dt_median)) / dt_median > 0.01
             and trial_boundaries is None
@@ -1355,7 +1351,11 @@ class SIMPL:
         # ── Check speed prior against data ──
         displacements = np.sqrt(np.sum(np.diff(Xb, axis=0) ** 2, axis=1))
         median_speed = float(np.median(displacements / self.dt_))
-        if median_speed > 0 and self.speed_prior < 0.2 * median_speed:
+        if (
+            self.speed_prior is not None
+            and median_speed > 0
+            and self.speed_prior < 0.2 * median_speed
+        ):
             warnings.warn(
                 f"speed_prior ({self.speed_prior:.4g}) is much slower than the median behavioural speed "
                 f"({median_speed:.4g}). This may impede the decoded trajectory. "
@@ -1470,14 +1470,10 @@ class SIMPL:
 
     def _init_kalman_filter(self) -> None:
         """Set up the Kalman filter from prior parameters."""
-        speed_sigma = self.speed_prior * self.dt_
-
         # Kalman configuration
         self.speed_prior_requested_ = self.speed_prior
         self.kalman_off_speed_prior_ = 1e10
-        speed_prior_effective = (
-            self.speed_prior if self.use_kalman_smoothing else max(self.speed_prior, self.kalman_off_speed_prior_)
-        )
+        speed_prior_effective = self.speed_prior if self.speed_prior is not None else self.kalman_off_speed_prior_
         self.speed_prior_effective_ = speed_prior_effective
         speed_sigma = speed_prior_effective * self.dt_
 
@@ -1845,8 +1841,7 @@ class SIMPL:
             "dt": self.dt_,
             "trial_boundaries": trial_boundaries,
             "kernel_bandwidth": self.kernel_bandwidth,
-            "speed_prior": self.speed_prior,
-            "use_kalman_smoothing": int(self.use_kalman_smoothing),
+            "speed_prior": np.nan if self.speed_prior is None else self.speed_prior,
             "behavior_prior": np.nan if self.behavior_prior is None else self.behavior_prior,
             "is_1D_angular": int(self.is_1D_angular),
             "align_mode": self.align_mode_ or "none",

--- a/src/simpl/simpl.py
+++ b/src/simpl/simpl.py
@@ -1351,11 +1351,7 @@ class SIMPL:
         # ── Check speed prior against data ──
         displacements = np.sqrt(np.sum(np.diff(Xb, axis=0) ** 2, axis=1))
         median_speed = float(np.median(displacements / self.dt_))
-        if (
-            self.speed_prior is not None
-            and median_speed > 0
-            and self.speed_prior < 0.2 * median_speed
-        ):
+        if self.speed_prior is not None and median_speed > 0 and self.speed_prior < 0.2 * median_speed:
             warnings.warn(
                 f"speed_prior ({self.speed_prior:.4g}) is much slower than the median behavioural speed "
                 f"({median_speed:.4g}). This may impede the decoded trajectory. "

--- a/src/simpl/utils.py
+++ b/src/simpl/utils.py
@@ -795,7 +795,7 @@ def save_results_to_netcdf(results: xr.Dataset, path: str) -> None:
     """Save a SIMPL results ``xr.Dataset`` to a netCDF file.
 
     Before writing, the function performs several type conversions required by
-    the netCDF4 format: boolean arrays (e.g. ``spike_mask``) are cast to
+    the NetCDF format: boolean arrays (e.g. ``spike_mask``) are cast to
     ``int32``, boolean ``attrs`` are cast to ``int``, and ``trial_slices``
     (a list of Python ``slice`` objects) is serialised to a flat ``int64``
     array.  Use ``load_results`` to reload and automatically reverse
@@ -814,7 +814,7 @@ def save_results_to_netcdf(results: xr.Dataset, path: str) -> None:
     for var in results_to_save.data_vars:
         if "reshape" in results_to_save[var].attrs:
             results_to_save[var].attrs["reshape"] = int(results_to_save[var].attrs["reshape"])
-    results_to_save.to_netcdf(path)
+    results_to_save.to_netcdf(path, engine="h5netcdf")
 
 
 def load_results(path: str) -> xr.Dataset:

--- a/tests/test_simpl.py
+++ b/tests/test_simpl.py
@@ -21,23 +21,23 @@ class TestSIMPLInit:
         assert not hasattr(model, "Y_")
         assert not hasattr(model, "results_")
 
-    def test_use_kalman_smoothing_argument(self, demo_data):
+    def test_speed_prior_none_disables_kalman_smoothing(self, demo_data):
         N = 500
         N_neurons = min(5, demo_data["Y"].shape[1])
-        model = SIMPL(use_kalman_smoothing=False, speed_prior=0.1)
+        model = SIMPL(speed_prior=None)
         model.fit(
             Y=demo_data["Y"][:N, :N_neurons],
             Xb=demo_data["Xb"][:N],
             time=demo_data["time"][:N],
             n_iterations=0,
         )
-        assert model.use_kalman_smoothing is False
+        assert model.speed_prior is None
         assert model.speed_prior_effective_ >= model.kalman_off_speed_prior_
 
     def test_kalman_smoothing_off_matches_likelihood_mode(self, demo_data):
         N = 500
         N_neurons = min(5, demo_data["Y"].shape[1])
-        model = SIMPL(use_kalman_smoothing=False)
+        model = SIMPL(speed_prior=None)
         model.fit(
             Y=demo_data["Y"][:N, :N_neurons],
             Xb=demo_data["Xb"][:N],
@@ -297,8 +297,7 @@ class TestSIMPLSaveLoadResults:
         N_neurons = min(5, demo_data["Y"].shape[1])
         model = SIMPL(
             kernel_bandwidth=0.03,
-            speed_prior=0.2,
-            use_kalman_smoothing=False,
+            speed_prior=None,
             behavior_prior=0.4,
             is_1D_angular=False,
             bin_size=0.05,
@@ -316,8 +315,7 @@ class TestSIMPLSaveLoadResults:
         )
 
         assert model.results_.attrs["kernel_bandwidth"] == 0.03
-        assert model.results_.attrs["speed_prior"] == 0.2
-        assert model.results_.attrs["use_kalman_smoothing"] == 0
+        assert np.isnan(model.results_.attrs["speed_prior"])
         assert model.results_.attrs["behavior_prior"] == 0.4
         assert model.results_.attrs["is_1D_angular"] == 0
         assert model.results_.attrs["bin_size"] == 0.05
@@ -335,7 +333,7 @@ class TestSIMPLSaveLoadResults:
         assert "F" in loaded
         assert loaded.F.shape == model.results_.F.shape
         assert loaded.attrs["kernel_bandwidth"] == 0.03
-        assert loaded.attrs["use_kalman_smoothing"] == 0
+        assert np.isnan(loaded.attrs["speed_prior"])
         np.testing.assert_allclose(loaded.attrs["env_extent"], np.array([0.0, 1.0, 0.0, 1.0]))
 
 


### PR DESCRIPTION
I removed the `use_kalman_smoothing` argument. You can now explicitly turn off Kalman smoothing by setting `speed_prior=None` and this is documented. 

This is a cleaner API with one less argument. 