### PR TITLE
Permit and document non-temporal SIMPL

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,14 +351,14 @@ Temporal structure enters SIMPL only through the Kalman smoothing prior. A tempo
 
 Once Kalman smoothing is disabled, SIMPL is, in effect, iterative maximum likelihood: each observation is decoded independently from the current receptive fields, then the receptive fields are refit from those decoded positions.
 
-If your samples do not have meaningful time stamps or temporal ordering, omit `time` when calling `fit()`:
+If your samples do not have meaningful time stamps or temporal ordering, pass `time=None` when calling `fit()`:
 
 ```python
 model = SIMPL(speed_prior=None)
-model.fit(Y, Xb)
+model.fit(Y, Xb, time=None)
 ```
 
-When `time` is omitted, SIMPL treats the data as non-temporal, replaces the missing time coordinate with `np.arange(T)`, and forcefully disables Kalman smoothing. In this setting, the saved `time` coordinate is better interpreted as trial/sample index rather than physical time.
+When `time=None`, SIMPL treats the data as non-temporal, replaces the missing time coordinate with `np.arange(T)`, and forcefully disables Kalman smoothing. In this setting, the saved `time` coordinate is better interpreted as trial/sample index rather than physical time.
 <!-- docs-nontemporal-end -->
 
 <!-- docs-angular-start -->

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 - **Fast** — fits 200 neurons over 1 hour of data in under 10 seconds on CPU. GPU optional but rarely needed.
 - **Scalable** - scales to state-of-the-art size neural datasets (1000s of neurons, millions of time points, billions of spikes) on CPU.
 - **Simple** — scikit-learn API. Minimal hyperparameters. Get started in <10 lines of code.
-- **Flexible** — works 1D angular data (e.g. head direction), 2D spatial data (e.g. place/grid cells), and higher dimensions. Trial-structure aware. Examples provided.
+- **Flexible** — 1D, 1D _angular_ (e.g. head direction), 2D spatial (e.g. place/grid cells), and higher dimensional data all permitted. Trial-structure aware. Temporal or non-temporal data.
 - **Rich outputs** — results stored as `xarray.Dataset` with per-iteration variables, metrics and units.
 - **Visual** — built-in plotting for trajectories, receptive fields, spike rasters, and fitting summaries.
 
@@ -165,7 +165,7 @@ $$
 {\color{1D5C84}\mathcal{N}\!\left(X_t; X_{t-\Delta t}, (\sigma_v\,\Delta t)^2 I\right)}
 $$
 
-Smaller `speed_prior` values enforce smoother decoded trajectories; larger values let each time bin follow the spike likelihood more freely. Set `speed_prior=None` to strictly disable Kalman smoothing entirely.
+Smaller `speed_prior` values enforce smoother decoded trajectories; larger values let each time bin follow the spike likelihood more freely. Set `speed_prior=None` disables Kalman smoothing. For data without meaningful temporal structure, see [Temporal vs. non-temporal datasets](#temporal-vs-non-temporal-datasets).
 
 **Optional (`behavior_prior`)**  
 SIMPL can also include a soft Gaussian tether to whatever the latent was initialised to (typically behavior), controlled by $\sigma_b$ (`behavior_prior`):
@@ -343,6 +343,23 @@ model.add_baselines(Xt=Xt, Ft=Ft, Ft_coords_dict={"y": ybins, "x": xbins})
 model.fit(Y, Xb, time, n_iterations=5)  # baselines computed automatically
 ```
 <!-- docs-baselines-end -->
+
+<!-- docs-nontemporal-start -->
+### Temporal vs. non-temporal datasets
+
+Temporal structure enters SIMPL only through the Kalman smoothing prior. A temporal dataset might be hippocampal navigation, where neighboring samples are adjacent moments in an animal's trajectory and smoothness over time is meaningful. A non-temporal dataset might be neural responses to visual stimuli, where each point is a separate trial and neighboring rows do not imply temporal continuity. 
+
+Once Kalman smoothing is disabled, SIMPL is, in effect, iterative maximum likelihood: each observation is decoded independently from the current receptive fields, then the receptive fields are refit from those decoded positions.
+
+If your samples do not have meaningful time stamps or temporal ordering, omit `time` when calling `fit()`:
+
+```python
+model = SIMPL(speed_prior=None)
+model.fit(Y, Xb)
+```
+
+When `time` is omitted, SIMPL treats the data as non-temporal, replaces the missing time coordinate with `np.arange(T)`, and forcefully disables Kalman smoothing. In this setting, the saved `time` coordinate is better interpreted as trial/sample index rather than physical time.
+<!-- docs-nontemporal-end -->
 
 <!-- docs-angular-start -->
 ### 1D angular / circular data

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -14,6 +14,12 @@
 
 {%
   include-markdown "../README.md"
+  start="<!-- docs-nontemporal-start -->"
+  end="<!-- docs-nontemporal-end -->"
+%}
+
+{%
+  include-markdown "../README.md"
   start="<!-- docs-angular-start -->"
   end="<!-- docs-angular-end -->"
 %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ markers = [
 ]
 filterwarnings = [
     "ignore:numpy.ndarray size changed:RuntimeWarning",
+    "ignore:Setting the shape on a NumPy array has been deprecated in NumPy 2\\.5\\.:DeprecationWarning:xarray\\.backends\\.netCDF4_",
 ]
 
 [tool.coverage.run]

--- a/src/simpl/simpl.py
+++ b/src/simpl/simpl.py
@@ -191,7 +191,7 @@ class SIMPL:
         self,
         Y: np.ndarray,
         Xb: np.ndarray,
-        time: np.ndarray,
+        time: np.ndarray | None = None,
         n_iterations: int = 5,
         trial_boundaries: np.ndarray | None = None,
         align_to_behavior: bool | str = "trajectory",
@@ -230,10 +230,12 @@ class SIMPL:
             Behavioral initialisation positions. This is the starting estimate of the latent
             trajectory, typically the tracked position of the animal. D is the number of
             latent dimensions (e.g. 2 for 2D position).
-        time : np.ndarray, shape (T,)
+        time : np.ndarray or None, shape (T,), optional
             Time stamps (in seconds) for each time bin. Values should be uniformly
-            increasing (Kalman filter is poorly defined otherwise. ``dt`` is automatically
-            inferred as ``median(diff(time))``.
+            increasing (Kalman filter is poorly defined otherwise). ``dt`` is automatically
+            inferred as ``median(diff(time))``. If None, the data are treated as
+            non-temporal: SIMPL uses ``np.arange(T)`` as a placeholder coordinate and
+            disables Kalman smoothing regardless of ``speed_prior``.
         n_iterations : int, optional
             Number of EM iterations to train after iteration 0. Set to 0 to run only the initial
             M-step (useful for manual iteration control via ``_fit_iteration()``). By default 5.
@@ -617,10 +619,11 @@ class SIMPL:
         results = utils.load_results(os.fspath(path))
 
         # Run full setup from saved data (environment, Kalman filter, masks, etc.)
+        saved_is_temporal = bool(results.attrs.get("is_temporal", 1))
         self.fit(
             Y=results["Y"].values,
             Xb=results["Xb"].values,
-            time=np.asarray(results.coords["time"].values, dtype=float),
+            time=np.asarray(results.coords["time"].values, dtype=float) if saved_is_temporal else None,
             n_iterations=0,
             trial_boundaries=np.atleast_1d(np.asarray(results.attrs.get("trial_boundaries", [0]), dtype=int)),
         )
@@ -1246,27 +1249,42 @@ class SIMPL:
     def _init_from_data(self, Y, Xb, time, trial_boundaries, align_to_behavior) -> None:
         """Validate inputs and initialise all internal state from raw data."""
         # ── Validate inputs ──
-        time = np.asarray(time, dtype=float)
-
         if len(Xb.shape) == 1:  # Handle 1D case where Xb is (T,) instead of (T, 1)
             Xb = Xb[:, np.newaxis]
         if Y.shape[0] != Xb.shape[0]:
             raise ValueError(f"Y and Xb must have the same number of time bins (got {Y.shape[0]} and {Xb.shape[0]})")
+
+        self.is_temporal_ = time is not None
+        if self.is_temporal_:
+            time = np.asarray(time, dtype=float)
+        else:
+            if self.speed_prior is not None:
+                warnings.warn(
+                    "time was not provided, so SIMPL is treating the data as non-temporal. "
+                    "Kalman smoothing is disabled and speed_prior is ignored. "
+                    "Set speed_prior=None to silence this warning."
+                )
+            time = np.arange(Y.shape[0], dtype=float)
+
         if time.ndim != 1:
             raise ValueError(f"time must be a 1D array (got shape {time.shape})")
         if Y.shape[0] != len(time):
             raise ValueError(f"Y and time must have the same length (got {Y.shape[0]} and {len(time)})")
-        if len(time) < 2:
+        if self.is_temporal_ and len(time) < 2:
             raise ValueError("time must contain at least 2 samples so dt can be inferred")
         if not np.all(np.isfinite(time)):
             raise ValueError("time must contain only finite values")
 
         dt = np.diff(time)
-        if not np.all(dt > 0):
-            raise ValueError("time must be strictly increasing")
-        dt_median = np.median(dt)
+        if self.is_temporal_:
+            if not np.all(dt > 0):
+                raise ValueError("time must be strictly increasing")
+            dt_median = np.median(dt)
+        else:
+            dt_median = 1.0
         if (
-            self.speed_prior is not None
+            self.is_temporal_
+            and self.speed_prior is not None
             and dt_median > 0
             and np.max(np.abs(dt - dt_median)) / dt_median > 0.01
             and trial_boundaries is None
@@ -1342,7 +1360,7 @@ class SIMPL:
         self.Xb_ = jax.device_put(jnp.array(Xb), device)
         self.time_ = jax.device_put(jnp.array(time), device)
         self.neuron_ = jax.device_put(jnp.array(neurons), device)
-        self.dt_ = float(np.median(dt))
+        self.dt_ = float(dt_median)
 
         self.xF_ = jnp.array(self.environment_.flattened_discretised_coords)
         self.xF_shape_ = self.environment_.discrete_env_shape
@@ -1351,7 +1369,12 @@ class SIMPL:
         # ── Check speed prior against data ──
         displacements = np.sqrt(np.sum(np.diff(Xb, axis=0) ** 2, axis=1))
         median_speed = float(np.median(displacements / self.dt_))
-        if self.speed_prior is not None and median_speed > 0 and self.speed_prior < 0.2 * median_speed:
+        if (
+            self.is_temporal_
+            and self.speed_prior is not None
+            and median_speed > 0
+            and self.speed_prior < 0.2 * median_speed
+        ):
             warnings.warn(
                 f"speed_prior ({self.speed_prior:.4g}) is much slower than the median behavioural speed "
                 f"({median_speed:.4g}). This may impede the decoded trajectory. "
@@ -1469,7 +1492,9 @@ class SIMPL:
         # Kalman configuration
         self.speed_prior_requested_ = self.speed_prior
         self.kalman_off_speed_prior_ = 1e10
-        speed_prior_effective = self.speed_prior if self.speed_prior is not None else self.kalman_off_speed_prior_
+        speed_prior_effective = (
+            self.speed_prior if self.is_temporal_ and self.speed_prior is not None else self.kalman_off_speed_prior_
+        )
         self.speed_prior_effective_ = speed_prior_effective
         speed_sigma = speed_prior_effective * self.dt_
 
@@ -1835,9 +1860,10 @@ class SIMPL:
             "env_pad": self.environment_.pad,
             "bin_size": self.environment_.bin_size,
             "dt": self.dt_,
+            "is_temporal": int(self.is_temporal_),
             "trial_boundaries": trial_boundaries,
             "kernel_bandwidth": self.kernel_bandwidth,
-            "speed_prior": np.nan if self.speed_prior is None else self.speed_prior,
+            "speed_prior": np.nan if self.speed_prior is None or not self.is_temporal_ else self.speed_prior,
             "behavior_prior": np.nan if self.behavior_prior is None else self.behavior_prior,
             "is_1D_angular": int(self.is_1D_angular),
             "align_mode": self.align_mode_ or "none",

--- a/src/simpl/simpl.py
+++ b/src/simpl/simpl.py
@@ -1260,7 +1260,7 @@ class SIMPL:
         else:
             if self.speed_prior is not None:
                 warnings.warn(
-                    "time was not provided, so SIMPL is treating the data as non-temporal. "
+                    "time=None was passed, so SIMPL is treating the data as non-temporal. "
                     "Kalman smoothing is disabled and speed_prior is ignored. "
                     "Set speed_prior=None to silence this warning."
                 )

--- a/src/simpl/simpl.py
+++ b/src/simpl/simpl.py
@@ -191,7 +191,7 @@ class SIMPL:
         self,
         Y: np.ndarray,
         Xb: np.ndarray,
-        time: np.ndarray | None = None,
+        time: np.ndarray | None,
         n_iterations: int = 5,
         trial_boundaries: np.ndarray | None = None,
         align_to_behavior: bool | str = "trajectory",
@@ -230,7 +230,7 @@ class SIMPL:
             Behavioral initialisation positions. This is the starting estimate of the latent
             trajectory, typically the tracked position of the animal. D is the number of
             latent dimensions (e.g. 2 for 2D position).
-        time : np.ndarray or None, shape (T,), optional
+        time : np.ndarray or None, shape (T,) or None
             Time stamps (in seconds) for each time bin. Values should be uniformly
             increasing (Kalman filter is poorly defined otherwise). ``dt`` is automatically
             inferred as ``median(diff(time))``. If None, the data are treated as

--- a/tests/test_simpl.py
+++ b/tests/test_simpl.py
@@ -34,6 +34,39 @@ class TestSIMPLInit:
         assert model.speed_prior is None
         assert model.speed_prior_effective_ >= model.kalman_off_speed_prior_
 
+    def test_time_none_uses_non_temporal_mode(self, demo_data):
+        N = 200
+        N_neurons = min(5, demo_data["Y"].shape[1])
+        model = SIMPL(speed_prior=None)
+        model.fit(
+            Y=demo_data["Y"][:N, :N_neurons],
+            Xb=demo_data["Xb"][:N],
+            n_iterations=0,
+        )
+
+        assert model.is_temporal_ is False
+        np.testing.assert_array_equal(np.asarray(model.time_), np.arange(N))
+        assert model.dt_ == 1.0
+        assert model.speed_prior_effective_ >= model.kalman_off_speed_prior_
+        assert model.results_.attrs["is_temporal"] == 0
+        assert np.isnan(model.results_.attrs["speed_prior"])
+
+    def test_time_none_warns_when_speed_prior_would_be_ignored(self, demo_data):
+        N = 200
+        N_neurons = min(5, demo_data["Y"].shape[1])
+        model = SIMPL(speed_prior=0.1)
+
+        with pytest.warns(UserWarning, match="non-temporal"):
+            model.fit(
+                Y=demo_data["Y"][:N, :N_neurons],
+                Xb=demo_data["Xb"][:N],
+                n_iterations=0,
+            )
+
+        assert model.is_temporal_ is False
+        assert model.speed_prior_effective_ >= model.kalman_off_speed_prior_
+        assert np.isnan(model.results_.attrs["speed_prior"])
+
     def test_kalman_smoothing_off_matches_likelihood_mode(self, demo_data):
         N = 500
         N_neurons = min(5, demo_data["Y"].shape[1])

--- a/tests/test_simpl.py
+++ b/tests/test_simpl.py
@@ -41,6 +41,7 @@ class TestSIMPLInit:
         model.fit(
             Y=demo_data["Y"][:N, :N_neurons],
             Xb=demo_data["Xb"][:N],
+            time=None,
             n_iterations=0,
         )
 
@@ -60,6 +61,7 @@ class TestSIMPLInit:
             model.fit(
                 Y=demo_data["Y"][:N, :N_neurons],
                 Xb=demo_data["Xb"][:N],
+                time=None,
                 n_iterations=0,
             )
 


### PR DESCRIPTION
# Non-temporal SIMPL

## Summary

This PR adds support for fitting SIMPL to datasets without meaningful temporal structure. `fit()` now accepts `time=None`, treats the rows of `Y`/`Xb` as independent samples or trials, creates a placeholder coordinate `np.arange(T)`, and disables Kalman smoothing for that fit.

It also documents temporal vs. non-temporal usage and adds regression coverage for the new mode.

## API Changes

- `SIMPL.fit(..., time=...)` now accepts `time=None`.
- Omitting `time` is the signal that the dataset is non-temporal.
- In non-temporal mode:
  - `model.is_temporal_` is `False`.
  - `model.time_` is `np.arange(T)`.
  - `model.dt_` is `1.0`.
  - Kalman smoothing is forcefully disabled.
  - saved results include `is_temporal = 0`.
  - saved `speed_prior` is `NaN`, because any numeric speed prior is ignored.
- If `time=None` and `speed_prior` is numeric, SIMPL emits a warning explaining that the data are treated as non-temporal and `speed_prior` is ignored.
- Users can silence that warning and make intent explicit with:

```python
model = SIMPL(speed_prior=None)
model.fit(Y, Xb)
```

## Behavior Notes

Temporal structure enters SIMPL through the Kalman smoothing prior. Once smoothing is disabled, fitting is effectively iterative maximum likelihood: each observation is decoded independently from the current receptive fields, then receptive fields are refit from those decoded positions.

Examples:

- Temporal: hippocampal navigation, where adjacent samples are adjacent moments in an animal trajectory.
- Non-temporal: visual stimulus trials, where each row is a separate trial and neighboring rows do not imply temporal continuity.

In non-temporal mode, the `time` coordinate in saved results is better interpreted as a trial/sample index than physical time.

## Implementation

- `SIMPL.fit()` signature changed from `time: np.ndarray` to `time: np.ndarray | None`.
- `_init_from_data()` now derives `is_temporal_` from whether `time` was supplied.
- Time validation, nonuniform-time warnings, and low-speed-prior warnings only apply to temporal fits.
- `_init_kalman_filter()` uses the high internal off-prior when either:
  - `time is None`, or
  - `speed_prior is None`.
- `load()` restores non-temporal saved results by checking the saved `is_temporal` attr and passing `time=None` back through setup.

## Docs

- README feature text now mentions temporal and non-temporal data.
- Model docs keep only a short pointer from `speed_prior` to the new section.
- Advanced Usage now includes `Temporal vs. non-temporal datasets`.

## Tests

Added coverage for:

- `time=None` creates non-temporal mode and placeholder trial/sample coordinates.
- numeric `speed_prior` with `time=None` warns and is ignored.
- non-temporal mode uses the same no-smoothing behavior as `speed_prior=None`.
- save/load metadata records `is_temporal` and omits numeric `speed_prior` when smoothing is disabled.

Also added a narrow pytest warning filter for the known third-party xarray/netCDF4 NumPy 2.5 deprecation, without adding new runtime dependencies.
