### PR TITLE
Change the method used for calculating log factorial

### DIFF
--- a/src/simpl/kalman.py
+++ b/src/simpl/kalman.py
@@ -252,7 +252,7 @@ class KalmanFilter:
         Parameters
         ----------
         Y : jax.Array, shape (T, dim_Y)
-            The observation means.
+            The observation
         U : jax.Array, shape (T, dim_U), optional
             The control inputs (defaults to zeros if not provided).
         mu0 : jax.Array, shape (dim_Z,), optional
@@ -500,7 +500,7 @@ class KalmanFilter:
         Parameters
         ----------
         Y : jax.Array, shape (T, dim_Y)
-            The observation means
+            The observation
         mu : jax.Array, shape (T, dim_Z)
             The posterior state means
         sigma : jax.Array, shape (T, dim_Z, dim_Z)
@@ -582,7 +582,7 @@ def _kalman_filter(
     Parameters
     ----------
     Y : jax.Array, shape (T, dim_Y)
-        The observation means
+        The observation
     U : jax.Array, shape (T, dim_U)
         The control inputs
     mu0 : jax.Array, shape (dim_Z,)

--- a/src/simpl/kde.py
+++ b/src/simpl/kde.py
@@ -20,6 +20,7 @@ from functools import partial
 import jax
 import jax.numpy as jnp
 from jax import vmap
+from jax.scipy.special import gammaln 
 
 from simpl.utils import _bin_indices_minuspi_pi, _circular_conv_fft_1d
 
@@ -34,10 +35,9 @@ __all__ = [
 ]
 
 
-def _log_factorial_stirling(spikes: jax.Array) -> jax.Array:
-    """Stirling's approximation of log(spikes!), with manual correction for 0! = 1."""
-    spikes_ = jnp.where(spikes == 0, 1, spikes)
-    return jnp.log(jnp.sqrt(2 * jnp.pi)) + (spikes_ + 0.5) * jnp.log(spikes_) - spikes_
+def _log_factorial_gamma(spikes: jax.Array) -> jax.Array:
+    """Compute log(X!) via the gamma function, which is faster and more accurate than Stirling's approximation."""
+    return gammaln(spikes+1)
 
 
 def gaussian_kernel(
@@ -228,7 +228,7 @@ def poisson_log_likelihood(
     """
     assert spikes.shape == rates.shape, f"spikes {spikes.shape} and rates {rates.shape} must have the same shape"
 
-    log_spikecount_factorial = _log_factorial_stirling(spikes)
+    log_spikecount_factorial = _log_factorial_gamma(spikes)
 
     return (spikes * jnp.log(rates + 1e-3)) - rates - log_spikecount_factorial
 
@@ -262,7 +262,7 @@ def poisson_log_likelihood_maps(
     if mask is None:
         mask = jnp.ones_like(spikes, dtype=bool)
 
-    log_spikecount_factorial = _log_factorial_stirling(spikes)
+    log_spikecount_factorial = _log_factorial_gamma(spikes)
 
     return (
         (mask * spikes) @ jnp.log(mean_rate + 1e-3)
@@ -314,7 +314,7 @@ def get_ll_and_bps_splits(
     @jax.jit
     def _batch_sums(Y_b, FX_b, mask_b):
         """Per-batch partial sums for both splits (suffix 0 = train, 1 = val)."""
-        log_fact = _log_factorial_stirling(Y_b)
+        log_fact = _log_factorial_gamma(Y_b)
         ll = poisson_log_likelihood(Y_b, FX_b)  # model per-bin log-likelihood
         out = {}
         for s, m in (("0", mask_b), ("1", ~mask_b)):

--- a/src/simpl/kde.py
+++ b/src/simpl/kde.py
@@ -20,7 +20,7 @@ from functools import partial
 import jax
 import jax.numpy as jnp
 from jax import vmap
-from jax.scipy.special import gammaln 
+from jax.scipy.special import gammaln
 
 from simpl.utils import _bin_indices_minuspi_pi, _circular_conv_fft_1d
 
@@ -37,7 +37,7 @@ __all__ = [
 
 def _log_factorial_gamma(spikes: jax.Array) -> jax.Array:
     """Compute log(X!) via the gamma function, which is faster and more accurate than Stirling's approximation."""
-    return gammaln(spikes+1)
+    return gammaln(spikes + 1)
 
 
 def gaussian_kernel(


### PR DESCRIPTION
https://github.com/TomGeorge1234/SIMPL/issues/111

SIMPL currently uses the Stirling approximation to calculate the log-factorial during the loglikelihood calculation.

However, the Stirling approximation of log-factorial is inaccurate in low-number regimes. 
Instead of this, we could use the gamma function where $\log(y!) = \log\Gamma(y+1)$.

JAX has this as `jax.scipy.special.gammaln`, and it is more accurate than stirling method and also faster.

`_log_factorial` is used in `logPYXF`, `logPYXF_val`, and the change from `_log_factorial_stirling` to `_log_factorial_gamma` makes a substantial change to the metric value (ranging from x2 to x10 change).

This is because in a low spike count regime, the Stirling approximation causes a larger error.
```
log_factorial_exact(1) = 0
_log_factorial_stirling(1) = -0.08106148
_log_factorial_gamma(1) = 4.77e-7
```

```
log_factorial_exact(2) = 0.69314718
_log_factorial_stirling(2) = 0.65180635
_log_factorial_gamma(2) = 0.6931474
```

`_log_factorial` is also used in the decoding step and in calculating the bits-per-spike metric.
In the bits-per-spike metric, `_log_factorial` is cancelled out. 
In the decoding step, `_log_factorial` is a constant term added to the likelihood map and does not affect the result.

I ran both versions, and this does not change anything other than `logPYXF`. 
For future users reporting `logPYXF` instead of `bits-per-spike`, I think this change is quite important.
