### PR TITLE
Fix control input not being passed to smoother bug

### DIFF
--- a/src/simpl/simpl.py
+++ b/src/simpl/simpl.py
@@ -1066,6 +1066,7 @@ class SIMPL:
         mu_s, sigma_s = self.kalman_filter_.smooth(
             mus_f=mu_f,
             sigmas_f=sigma_f,
+            U=U,
             is_trial_end=is_trial_end,
         )
 


### PR DESCRIPTION
Fixes bug where control input wasn't being passed to the Kalman smoother (was being passed to the filter) 