### PR TITLE
Circular gaussian fit

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ When `time=None`, SIMPL treats the data as non-temporal, replaces the missing ti
 <!-- docs-angular-start -->
 ### 1D angular / circular data
 
-SIMPL supports 1D circular latent variables (e.g. head direction) via the `is_1D_angular` flag. When enabled, the environment is fixed to [-π, π), angular KDE is used for receptive fields, likelihood maps are summarized using circular Gaussian moments, and the Kalman filter wraps its state to [-π, π) after every predict, update, and smooth step.
+SIMPL supports 1D circular latent variables (e.g. head direction) via the `is_1D_angular` flag. When enabled, the environment is fixed to [-π, π), angular KDE is used for receptive fields, and the Kalman filter wraps its state to [-π, π) after every predict, update, and smooth step.
 
 ```python
 model = SIMPL(
@@ -454,16 +454,8 @@ from simpl import accumulate_spikes, coarsen_dt
 # Roll up spikes into wider time bins (e.g. sum every 2 bins)
 Y_coarse, Xb_coarse, time_coarse = coarsen_dt(Y, Xb, time, dt_multiplier=2)
 
-# Accumulate spikes independently within each trial. Trimming discards the
-# first window - 1 bins of every trial, where the causal window is incomplete.
-Y_accum, keep, trial_boundaries_accum = accumulate_spikes(
-    Y,
-    window=3,
-    trial_boundaries=trial_boundaries,
-    trim_incomplete=True,
-)
-Xb_accum = Xb[keep]
-time_accum = time[keep]
+# Accumulate spikes with a causal sliding window
+Y_accum = accumulate_spikes(Y, window=3)
 ```
 <!-- docs-preprocessing-end -->
 

--- a/README.md
+++ b/README.md
@@ -374,7 +374,7 @@ When `time=None`, SIMPL treats the data as non-temporal, replaces the missing ti
 <!-- docs-angular-start -->
 ### 1D angular / circular data
 
-SIMPL supports 1D circular latent variables (e.g. head direction) via the `is_1D_angular` flag. When enabled, the environment is fixed to [-π, π), angular KDE is used for receptive fields, and the Kalman filter wraps its state to [-π, π) after every predict, update, and smooth step.
+SIMPL supports 1D circular latent variables (e.g. head direction) via the `is_1D_angular` flag. When enabled, the environment is fixed to [-π, π), angular KDE is used for receptive fields, likelihood maps are summarized using circular Gaussian moments, and the Kalman filter wraps its state to [-π, π) after every predict, update, and smooth step.
 
 ```python
 model = SIMPL(
@@ -432,8 +432,16 @@ from simpl import accumulate_spikes, coarsen_dt
 # Roll up spikes into wider time bins (e.g. sum every 2 bins)
 Y_coarse, Xb_coarse, time_coarse = coarsen_dt(Y, Xb, time, dt_multiplier=2)
 
-# Accumulate spikes with a causal sliding window
-Y_accum = accumulate_spikes(Y, window=3)
+# Accumulate spikes independently within each trial. Trimming discards the
+# first window - 1 bins of every trial, where the causal window is incomplete.
+Y_accum, keep, trial_boundaries_accum = accumulate_spikes(
+    Y,
+    window=3,
+    trial_boundaries=trial_boundaries,
+    trim_incomplete=True,
+)
+Xb_accum = Xb[keep]
+time_accum = time[keep]
 ```
 <!-- docs-preprocessing-end -->
 

--- a/src/simpl/kde.py
+++ b/src/simpl/kde.py
@@ -356,7 +356,7 @@ def decode_observations(
     mask: jax.Array,
     batch_size: int | None = None,
     return_log_maps: bool = False,
-    gaussian_fit_mode: str = "linear",
+    is_1D_angular: bool = False,
 ) -> tuple:
     """Compute Poisson likelihood maps, fit Gaussian observations, and flag silent bins.
 
@@ -379,10 +379,10 @@ def decode_observations(
         to target ~64 MB peak memory for the likelihood tensor.
     return_log_maps : bool
         If True, also return the full ``(T, N_bins)`` log-likelihood maps.
-    gaussian_fit_mode : {"linear", "circular"}, optional
-        How to reduce each likelihood map to Gaussian observation moments.
-        Circular mode uses a circular mean and wrapped residual variance and
-        requires a 1-D angular grid. By default ``"linear"``.
+    is_1D_angular : bool, optional
+        Whether ``xF`` is a one-dimensional angular grid. Angular likelihood
+        maps always use a circular mean and wrapped residual variance. By
+        default False.
 
     Returns
     -------
@@ -395,9 +395,7 @@ def decode_observations(
     """
     from simpl.utils import fit_gaussian  # local to avoid circular import
 
-    if gaussian_fit_mode not in ("linear", "circular"):
-        raise ValueError(f"gaussian_fit_mode must be 'linear' or 'circular', got {gaussian_fit_mode!r}")
-    if gaussian_fit_mode == "circular" and (xF.ndim != 2 or xF.shape[1] != 1):
+    if is_1D_angular and (xF.ndim != 2 or xF.shape[1] != 1):
         raise ValueError(f"Circular Gaussian fitting requires xF with shape (N_bins, 1), got {xF.shape}")
 
     T = spikes.shape[0]
@@ -412,7 +410,7 @@ def decode_observations(
     def _process_batch(xF, spikes_batch, mean_rate, mask_batch, _return_log_maps=False):
         log_maps = poisson_log_likelihood_maps(spikes_batch, mean_rate, mask=mask_batch)
         log_maps = log_maps - jnp.max(log_maps, axis=1)[:, None]  # shift max to 0 to avoid NaNs in exp
-        mu, mode, sigma = fit_gaussian(xF, jnp.exp(log_maps), mode=gaussian_fit_mode)
+        mu, mode, sigma = fit_gaussian(xF, jnp.exp(log_maps), is_1D_angular=is_1D_angular)
         no_spk = jnp.sum(spikes_batch * mask_batch, axis=1) == 0
         if _return_log_maps:
             return mu, mode, sigma, no_spk, log_maps

--- a/src/simpl/kde.py
+++ b/src/simpl/kde.py
@@ -356,6 +356,7 @@ def decode_observations(
     mask: jax.Array,
     batch_size: int | None = None,
     return_log_maps: bool = False,
+    gaussian_fit_mode: str = "linear",
 ) -> tuple:
     """Compute Poisson likelihood maps, fit Gaussian observations, and flag silent bins.
 
@@ -378,6 +379,10 @@ def decode_observations(
         to target ~64 MB peak memory for the likelihood tensor.
     return_log_maps : bool
         If True, also return the full ``(T, N_bins)`` log-likelihood maps.
+    gaussian_fit_mode : {"linear", "circular"}, optional
+        How to reduce each likelihood map to Gaussian observation moments.
+        Circular mode uses a circular mean and wrapped residual variance and
+        requires a 1-D angular grid. By default ``"linear"``.
 
     Returns
     -------
@@ -389,6 +394,11 @@ def decode_observations(
         Only returned when ``return_log_maps`` is True.
     """
     from simpl.utils import fit_gaussian  # local to avoid circular import
+
+    if gaussian_fit_mode not in ("linear", "circular"):
+        raise ValueError(f"gaussian_fit_mode must be 'linear' or 'circular', got {gaussian_fit_mode!r}")
+    if gaussian_fit_mode == "circular" and (xF.ndim != 2 or xF.shape[1] != 1):
+        raise ValueError(f"Circular Gaussian fitting requires xF with shape (N_bins, 1), got {xF.shape}")
 
     T = spikes.shape[0]
     N_bins = xF.shape[0]
@@ -402,7 +412,7 @@ def decode_observations(
     def _process_batch(xF, spikes_batch, mean_rate, mask_batch, _return_log_maps=False):
         log_maps = poisson_log_likelihood_maps(spikes_batch, mean_rate, mask=mask_batch)
         log_maps = log_maps - jnp.max(log_maps, axis=1)[:, None]  # shift max to 0 to avoid NaNs in exp
-        mu, mode, sigma = fit_gaussian(xF, jnp.exp(log_maps))
+        mu, mode, sigma = fit_gaussian(xF, jnp.exp(log_maps), mode=gaussian_fit_mode)
         no_spk = jnp.sum(spikes_batch * mask_batch, axis=1) == 0
         if _return_log_maps:
             return mu, mode, sigma, no_spk, log_maps

--- a/src/simpl/simpl.py
+++ b/src/simpl/simpl.py
@@ -1913,7 +1913,6 @@ class SIMPL:
         if is_1D_angular and D != 1:
             raise ValueError(f"Circular trial initialization requires one-dimensional modes, got D={D}")
 
-        # Convert to numpy for the loop to avoid JAX tracing overhead
         mode_np = np.array(mode_l)
         mu0_all = np.zeros((T, D))
         sigma0_all = np.zeros((T, D, D))
@@ -1921,21 +1920,9 @@ class SIMPL:
             modes = mode_np[trial_slice]
             if is_1D_angular:
                 angles = modes[:, 0]
-                sin_mean = np.sin(angles).mean()
-                cos_mean = np.cos(angles).mean()
-
-                # The circular mean is undefined for zero resultant length.
-                # Use the first mode as a deterministic centre; the wrapped
-                # variance remains broad and therefore downweights this prior.
-                if sin_mean**2 + cos_mean**2 > 1e-12:
-                    mean_angle = np.arctan2(sin_mean, cos_mean)
-                else:
-                    mean_angle = angles[0]
-                mean_angle = (mean_angle + np.pi) % (2 * np.pi) - np.pi
-
-                residuals = (angles - mean_angle + np.pi) % (2 * np.pi) - np.pi
-                mu = np.array([mean_angle])
-                sigma = np.array([[(residuals**2).mean()]])
+                mean_angle, variance = utils._circular_mean_and_variance(angles=angles, weights=None)
+                mu = np.asarray(mean_angle)[None]
+                sigma = np.asarray(variance)[None, None]
             else:
                 mu = modes.mean(axis=0)
                 sigma = (1 / len(modes)) * ((modes - mu).T @ (modes - mu))

--- a/src/simpl/simpl.py
+++ b/src/simpl/simpl.py
@@ -39,7 +39,6 @@ class SIMPL:
         behavior_prior: float | None = None,
         # Environment parameters
         is_1D_angular: bool = False,
-        gaussian_fit_mode: str = "auto",
         bin_size: float = 0.02,
         env_pad: float = 0.0,
         env_lims: tuple | None = None,
@@ -107,18 +106,11 @@ class SIMPL:
         is_1D_angular : bool, optional
             Whether the latent space is 1D angular/circular (e.g. head direction data in
             radians). If True, angular KDE is used, the Kalman filter wraps its state to
-            [-pi, pi) after every predict/update/smooth step, and the environment is fixed
-            to [-pi, pi). The wrapped Kalman approximation assumes a tight posterior
-            (sigma << 2*pi); results may degrade when posterior uncertainty is large relative
-            to the circular domain. By default False.
-        gaussian_fit_mode : {"auto", "linear", "circular"}, optional
-            How likelihood maps are reduced to Gaussian observations for Kalman decoding.
-            ``"linear"`` uses ordinary Euclidean mean and covariance. ``"circular"`` uses
-            a circular mean and wrapped residual variance and requires
-            ``is_1D_angular=True``. ``"auto"`` selects circular fitting for angular models
-            and linear fitting otherwise. The resolved runtime switch is stored in
-            ``self._gaussian_fit_mode`` and can be manually changed before ``fit()`` or
-            ``predict()`` to compare the two methods. By default ``"auto"``.
+            [-pi, pi) after every predict/update/smooth step, likelihood maps are reduced
+            using circular Gaussian moments, and the environment is fixed to [-pi, pi).
+            The wrapped Kalman approximation assumes a tight posterior (sigma << 2*pi);
+            results may degrade when posterior uncertainty is large relative to the circular
+            domain. By default False.
         bin_size : float, optional
             Spatial bin size for discretising the environment, in the same units as the latent
             space. Controls the resolution of the receptive field grid. Smaller bins give
@@ -173,15 +165,6 @@ class SIMPL:
         self.speed_prior = speed_prior
         self.behavior_prior = behavior_prior
         self.is_1D_angular = is_1D_angular
-        self.gaussian_fit_mode = gaussian_fit_mode
-        if gaussian_fit_mode not in ("auto", "linear", "circular"):
-            raise ValueError(f"gaussian_fit_mode must be 'auto', 'linear', or 'circular', got {gaussian_fit_mode!r}")
-        if gaussian_fit_mode == "auto":
-            self._gaussian_fit_mode = "circular" if is_1D_angular else "linear"
-        else:
-            self._gaussian_fit_mode = gaussian_fit_mode
-        if self._gaussian_fit_mode == "circular" and not is_1D_angular:
-            raise ValueError("gaussian_fit_mode='circular' requires is_1D_angular=True")
 
         # Environment config
         self.bin_size = bin_size
@@ -617,7 +600,7 @@ class SIMPL:
             original training run.** This method does NOT read or override
             hyperparameters from the saved file — it trusts whatever was passed to
             ``__init__``. If any parameter differs (``speed_prior``,
-            ``kernel_bandwidth``, ``gaussian_fit_mode``, ``bin_size``, ``env_pad``, ``val_frac``,
+            ``kernel_bandwidth``, ``bin_size``, ``env_pad``, ``val_frac``,
             ``random_seed``, etc.), the internal state (Kalman filter, spike mask,
             environment grid) will be inconsistent with the saved results, leading
             to silently incorrect behaviour on resume, predict, or further fitting.
@@ -1052,17 +1035,13 @@ class SIMPL:
 
         # Likelihood maps and Gaussian observation fits (batched internally)
         self._substatus("E···  likelihood")
-        if self._gaussian_fit_mode not in ("linear", "circular"):
-            raise ValueError(f"_gaussian_fit_mode must be 'linear' or 'circular', got {self._gaussian_fit_mode!r}")
-        if self._gaussian_fit_mode == "circular" and not self.is_1D_angular:
-            raise ValueError("_gaussian_fit_mode='circular' requires is_1D_angular=True")
         obs = kde.decode_observations(
             self.xF_,
             Y,
             F,
             mask,
             return_log_maps=store_log_maps,
-            gaussian_fit_mode=self._gaussian_fit_mode,
+            is_1D_angular=self.is_1D_angular,
         )
         if store_log_maps:
             mu_l, mode_l, sigma_l, no_spikes, logPYXF_maps = obs
@@ -1944,7 +1923,6 @@ class SIMPL:
             "speed_prior": np.nan if self.speed_prior is None or not self.is_temporal_ else self.speed_prior,
             "behavior_prior": np.nan if self.behavior_prior is None else self.behavior_prior,
             "is_1D_angular": int(self.is_1D_angular),
-            "gaussian_fit_mode": self._gaussian_fit_mode,
             "align_mode": self.align_mode_ or "none",
             "environment_provided": int(self._environment_override is not None),
             "val_frac": self.val_frac,

--- a/src/simpl/simpl.py
+++ b/src/simpl/simpl.py
@@ -1077,7 +1077,11 @@ class SIMPL:
         )
 
         # Per-trial initial states (mean and covariance of likelihood modes over each trial)
-        mu0_all, sigma0_all = self._per_trial_initial_states(mode_l, trial_slices)
+        mu0_all, sigma0_all = self._per_trial_initial_states(
+            mode_l,
+            trial_slices,
+            is_1D_angular=self.is_1D_angular,
+        )
 
         # Single-pass filter and smooth
         self._substatus("E···  kalman filter")
@@ -1868,11 +1872,13 @@ class SIMPL:
         return trial_boundaries, trial_slices, jnp.array(is_boundary), jnp.array(is_trial_end)
 
     @staticmethod
-    def _per_trial_initial_states(mode_l, trial_slices):
+    def _per_trial_initial_states(mode_l, trial_slices, is_1D_angular=False):
         """Compute per-trial initial states from likelihood modes.
 
-        For each trial, the initial mean is the average of the likelihood modes
-        over the trial, and the initial covariance is the sample covariance.
+        For linear data, the initial mean and covariance are ordinary Euclidean
+        moments of the likelihood modes in each trial. For 1-D angular data,
+        the mean is circular and the covariance is the mean squared wrapped
+        residual around that mean, expressed in radians squared.
 
         Parameters
         ----------
@@ -1880,6 +1886,9 @@ class SIMPL:
             Likelihood modes at each timestep.
         trial_slices : list[slice]
             Trial boundaries as slices.
+        is_1D_angular : bool, optional
+            Whether to use circular statistics. Circular initialization
+            requires one-dimensional modes. By default False.
 
         Returns
         -------
@@ -1889,14 +1898,35 @@ class SIMPL:
             Per-timestep initial covariances (meaningful only at trial starts).
         """
         T, D = mode_l.shape
+        if is_1D_angular and D != 1:
+            raise ValueError(f"Circular trial initialization requires one-dimensional modes, got D={D}")
+
         # Convert to numpy for the loop to avoid JAX tracing overhead
         mode_np = np.array(mode_l)
         mu0_all = np.zeros((T, D))
         sigma0_all = np.zeros((T, D, D))
         for trial_slice in trial_slices:
             modes = mode_np[trial_slice]
-            mu = modes.mean(axis=0)
-            sigma = (1 / len(modes)) * ((modes - mu).T @ (modes - mu))
+            if is_1D_angular:
+                angles = modes[:, 0]
+                sin_mean = np.sin(angles).mean()
+                cos_mean = np.cos(angles).mean()
+
+                # The circular mean is undefined for zero resultant length.
+                # Use the first mode as a deterministic centre; the wrapped
+                # variance remains broad and therefore downweights this prior.
+                if sin_mean**2 + cos_mean**2 > 1e-12:
+                    mean_angle = np.arctan2(sin_mean, cos_mean)
+                else:
+                    mean_angle = angles[0]
+                mean_angle = (mean_angle + np.pi) % (2 * np.pi) - np.pi
+
+                residuals = (angles - mean_angle + np.pi) % (2 * np.pi) - np.pi
+                mu = np.array([mean_angle])
+                sigma = np.array([[(residuals**2).mean()]])
+            else:
+                mu = modes.mean(axis=0)
+                sigma = (1 / len(modes)) * ((modes - mu).T @ (modes - mu))
             mu0_all[trial_slice.start] = mu
             sigma0_all[trial_slice.start] = sigma
         return jnp.array(mu0_all), jnp.array(sigma0_all)

--- a/src/simpl/simpl.py
+++ b/src/simpl/simpl.py
@@ -39,6 +39,7 @@ class SIMPL:
         behavior_prior: float | None = None,
         # Environment parameters
         is_1D_angular: bool = False,
+        gaussian_fit_mode: str = "auto",
         bin_size: float = 0.02,
         env_pad: float = 0.0,
         env_lims: tuple | None = None,
@@ -110,6 +111,14 @@ class SIMPL:
             to [-pi, pi). The wrapped Kalman approximation assumes a tight posterior
             (sigma << 2*pi); results may degrade when posterior uncertainty is large relative
             to the circular domain. By default False.
+        gaussian_fit_mode : {"auto", "linear", "circular"}, optional
+            How likelihood maps are reduced to Gaussian observations for Kalman decoding.
+            ``"linear"`` uses ordinary Euclidean mean and covariance. ``"circular"`` uses
+            a circular mean and wrapped residual variance and requires
+            ``is_1D_angular=True``. ``"auto"`` selects circular fitting for angular models
+            and linear fitting otherwise. The resolved runtime switch is stored in
+            ``self._gaussian_fit_mode`` and can be manually changed before ``fit()`` or
+            ``predict()`` to compare the two methods. By default ``"auto"``.
         bin_size : float, optional
             Spatial bin size for discretising the environment, in the same units as the latent
             space. Controls the resolution of the receptive field grid. Smaller bins give
@@ -164,6 +173,15 @@ class SIMPL:
         self.speed_prior = speed_prior
         self.behavior_prior = behavior_prior
         self.is_1D_angular = is_1D_angular
+        self.gaussian_fit_mode = gaussian_fit_mode
+        if gaussian_fit_mode not in ("auto", "linear", "circular"):
+            raise ValueError(f"gaussian_fit_mode must be 'auto', 'linear', or 'circular', got {gaussian_fit_mode!r}")
+        if gaussian_fit_mode == "auto":
+            self._gaussian_fit_mode = "circular" if is_1D_angular else "linear"
+        else:
+            self._gaussian_fit_mode = gaussian_fit_mode
+        if self._gaussian_fit_mode == "circular" and not is_1D_angular:
+            raise ValueError("gaussian_fit_mode='circular' requires is_1D_angular=True")
 
         # Environment config
         self.bin_size = bin_size
@@ -599,7 +617,7 @@ class SIMPL:
             original training run.** This method does NOT read or override
             hyperparameters from the saved file — it trusts whatever was passed to
             ``__init__``. If any parameter differs (``speed_prior``,
-            ``kernel_bandwidth``, ``bin_size``, ``env_pad``, ``val_frac``,
+            ``kernel_bandwidth``, ``gaussian_fit_mode``, ``bin_size``, ``env_pad``, ``val_frac``,
             ``random_seed``, etc.), the internal state (Kalman filter, spike mask,
             environment grid) will be inconsistent with the saved results, leading
             to silently incorrect behaviour on resume, predict, or further fitting.
@@ -1034,7 +1052,18 @@ class SIMPL:
 
         # Likelihood maps and Gaussian observation fits (batched internally)
         self._substatus("E···  likelihood")
-        obs = kde.decode_observations(self.xF_, Y, F, mask, return_log_maps=store_log_maps)
+        if self._gaussian_fit_mode not in ("linear", "circular"):
+            raise ValueError(f"_gaussian_fit_mode must be 'linear' or 'circular', got {self._gaussian_fit_mode!r}")
+        if self._gaussian_fit_mode == "circular" and not self.is_1D_angular:
+            raise ValueError("_gaussian_fit_mode='circular' requires is_1D_angular=True")
+        obs = kde.decode_observations(
+            self.xF_,
+            Y,
+            F,
+            mask,
+            return_log_maps=store_log_maps,
+            gaussian_fit_mode=self._gaussian_fit_mode,
+        )
         if store_log_maps:
             mu_l, mode_l, sigma_l, no_spikes, logPYXF_maps = obs
         else:
@@ -1066,6 +1095,7 @@ class SIMPL:
         mu_s, sigma_s = self.kalman_filter_.smooth(
             mus_f=mu_f,
             sigmas_f=sigma_f,
+            U=U,
             is_trial_end=is_trial_end,
         )
 
@@ -1884,6 +1914,7 @@ class SIMPL:
             "speed_prior": np.nan if self.speed_prior is None or not self.is_temporal_ else self.speed_prior,
             "behavior_prior": np.nan if self.behavior_prior is None else self.behavior_prior,
             "is_1D_angular": int(self.is_1D_angular),
+            "gaussian_fit_mode": self._gaussian_fit_mode,
             "align_mode": self.align_mode_ or "none",
             "environment_provided": int(self._environment_override is not None),
             "val_frac": self.val_frac,

--- a/src/simpl/utils.py
+++ b/src/simpl/utils.py
@@ -460,12 +460,20 @@ def correlation_at_lag(X1: jax.Array, X2: jax.Array, lag: int) -> jax.Array:
 # ──────────────────────────────────────────────────────────────────────────────
 
 
-def accumulate_spikes(Y: np.ndarray, window: int) -> np.ndarray:
+def accumulate_spikes(
+    Y: np.ndarray,
+    window: int,
+    trial_boundaries: np.ndarray | None = None,
+    *,
+    trim_incomplete: bool = False,
+) -> np.ndarray | tuple[np.ndarray, np.ndarray, np.ndarray]:
     """Causal rolling sum of spikes over a backward-looking window.
 
     Each time bin accumulates spikes from the current and previous
     ``window - 1`` bins. This is equivalent to smoothing the spikes with
-    a causal rectangular kernel.
+    a causal rectangular kernel. When ``trial_boundaries`` is provided, the
+    rolling window is reset at every trial start so spikes cannot leak between
+    trials.
 
     !!! warning
 
@@ -483,17 +491,84 @@ def accumulate_spikes(Y: np.ndarray, window: int) -> np.ndarray:
     window : int
         Number of bins to sum over (looking backwards). For example,
         ``window=5`` sums the current bin and the 4 preceding bins.
+    trial_boundaries : np.ndarray or None, optional
+        Indices where trials start, e.g. ``[0, 1000, 2000]``. The first
+        boundary must be 0. If None, all bins are treated as one trial.
+    trim_incomplete : bool, optional
+        If True, remove the first ``window - 1`` bins of every trial, where a
+        complete backward-looking window is unavailable. Since accumulation is
+        causal, no bins need to be removed from trial ends. This changes the
+        return value to ``(Y_accumulated, keep_mask, trial_boundaries)``. Use
+        ``keep_mask`` to trim aligned arrays such as ``Xb`` and ``time``. By
+        default False.
 
     Returns
     -------
     Y_accumulated : np.ndarray, shape (T, N_neurons)
-        Spike counts after causal rolling sum.
+        Spike counts after causal rolling sum. If ``trim_incomplete=True``, its
+        first dimension is shortened by ``window - 1`` bins per trial.
+    keep_mask : np.ndarray, shape (T,), optional
+        Boolean mask selecting retained input bins. Returned only when
+        ``trim_incomplete=True``.
+    trial_boundaries : np.ndarray, optional
+        Trial starts recalculated for the trimmed concatenated data. Returned
+        only when ``trim_incomplete=True``.
+
+    Examples
+    --------
+    Accumulate independently within trials and trim all aligned arrays:
+
+    >>> Y_accum, keep, boundaries = accumulate_spikes(
+    ...     Y, window=3, trial_boundaries=boundaries, trim_incomplete=True
+    ... )
+    >>> Xb, time = Xb[keep], time[keep]
     """
+    if isinstance(window, (bool, np.bool_)) or not isinstance(window, (int, np.integer)) or window < 1:
+        raise ValueError(f"window must be a positive integer, got {window!r}")
+
+    T = Y.shape[0]
+    if T == 0:
+        raise ValueError("Y must contain at least one time bin")
+
+    if trial_boundaries is None:
+        boundaries = np.array([0], dtype=int)
+    else:
+        boundaries = np.atleast_1d(np.asarray(trial_boundaries, dtype=int))
+
+    if boundaries.size == 0:
+        raise ValueError("trial_boundaries must contain at least one boundary (starting at 0)")
+    if boundaries[0] != 0:
+        raise ValueError("First trial boundary must be 0")
+    if boundaries[-1] >= T:
+        raise ValueError(f"Last trial boundary must be < len(Y) (got {boundaries[-1]} with len(Y)={T})")
+    if len(boundaries) > 1 and not np.all(np.diff(boundaries) > 0):
+        raise ValueError("Trial boundaries must be strictly increasing")
+
+    trial_ends = np.append(boundaries[1:], T)
     Y_out = np.zeros_like(Y)
-    for i in range(Y.shape[0]):
-        start = max(0, i - window + 1)
-        Y_out[i] = Y[start : i + 1].sum(axis=0)
-    return Y_out
+    for trial_start, trial_end in zip(boundaries, trial_ends):
+        for i in range(trial_start, trial_end):
+            window_start = max(trial_start, i - window + 1)
+            Y_out[i] = Y[window_start : i + 1].sum(axis=0)
+
+    if not trim_incomplete:
+        return Y_out
+
+    trimmed_trial_lengths = trial_ends - boundaries - (window - 1)
+    if np.any(trimmed_trial_lengths <= 0):
+        short_trials = np.flatnonzero(trimmed_trial_lengths <= 0)
+        raise ValueError(
+            f"Every trial must contain at least window={window} bins when trim_incomplete=True; "
+            f"trials {short_trials.tolist()} are too short"
+        )
+
+    keep_mask = np.zeros(T, dtype=bool)
+    for trial_start, trial_end in zip(boundaries, trial_ends):
+        keep_mask[trial_start + window - 1 : trial_end] = True
+
+    updated_boundaries = np.concatenate(([0], np.cumsum(trimmed_trial_lengths)[:-1])).astype(int)
+    return Y_out[keep_mask], keep_mask, updated_boundaries
+
 
 
 def coarsen_dt(

--- a/src/simpl/utils.py
+++ b/src/simpl/utils.py
@@ -558,8 +558,7 @@ def accumulate_spikes(
     retained_trial_lengths = trimmed_trial_lengths[trimmed_trial_lengths > 0]
     if retained_trial_lengths.size == 0:
         raise ValueError(
-            f"No trial contains at least window={window} bins, so no complete "
-            "accumulation window can be retained"
+            f"No trial contains at least window={window} bins, so no complete accumulation window can be retained"
         )
 
     keep_mask = np.zeros(T, dtype=bool)
@@ -568,7 +567,6 @@ def accumulate_spikes(
 
     updated_boundaries = np.concatenate(([0], np.cumsum(retained_trial_lengths)[:-1])).astype(int)
     return Y_out[keep_mask], keep_mask, updated_boundaries
-
 
 
 def coarsen_dt(

--- a/src/simpl/utils.py
+++ b/src/simpl/utils.py
@@ -159,24 +159,15 @@ def _fit_gaussian_linear(x: jax.Array, likelihoods: jax.Array) -> tuple[jax.Arra
 
 @jax.jit
 def _fit_gaussian_circular(x: jax.Array, likelihoods: jax.Array) -> tuple[jax.Array, jax.Array, jax.Array]:
-    """Fit circular mean and wrapped residual variance to 1-D angular likelihoods."""
-    sums = likelihoods.sum(axis=1)  # (T,)
-    angles = x[:, 0]  # (N_bins,)
+    """Fit circular mean and wrapped residual variance to 1-D angular likelihoods.
 
-    sin_mean = (likelihoods @ jnp.sin(angles)) / sums
-    cos_mean = (likelihoods @ jnp.cos(angles)) / sums
-    mu_angle = _wrap_minuspi_pi(jnp.arctan2(sin_mean, cos_mean))
+    x : jnp.ndarray, shape (N_bins, 1)
+    likelihoods : jnp.ndarray, shape (T, N_bins)
+    """
+    angles = x[:, 0]  # (N_bins,)
+    mu_angle, variance = _circular_mean_and_variance(angles=angles, weights=likelihoods)
 
     mode = x[jnp.argmax(likelihoods, axis=1)]  # (T, 1)
-
-    # A circular mean is undefined for a distribution with zero resultant
-    # length. Use the likelihood mode as a deterministic centre in that case;
-    # the wrapped variance remains broad, so the Kalman update downweights it.
-    resultant_squared = sin_mean**2 + cos_mean**2
-    mu_angle = jnp.where(resultant_squared > 1e-12, mu_angle, mode[:, 0])
-
-    residuals = _wrap_minuspi_pi(angles[None, :] - mu_angle[:, None])
-    variance = jnp.sum(likelihoods * residuals**2, axis=1) / sums
 
     return mu_angle[:, None], mode, variance[:, None, None]
 
@@ -275,6 +266,53 @@ def _wrap_minuspi_pi(theta: jax.Array) -> jax.Array:
         Angles wrapped to [-pi, pi)
     """
     return jnp.mod(theta + jnp.pi, _TAU) - jnp.pi
+
+
+def _circular_mean_and_variance(
+    angles: jax.Array,
+    weights: jax.Array | None = None,
+) -> tuple[jax.Array, jax.Array]:
+    """Compute a circular mean and mean squared wrapped residual.
+
+    Statistics are computed along the final axis. ``angles`` and ``weights``
+    are broadcast together, allowing a shared angular grid to be paired with a
+    batch of weight vectors. If the resultant length is effectively zero, the
+    angle with the greatest weight is used as a deterministic centre (the
+    first angle for unweighted samples).
+
+    Parameters
+    ----------
+    angles : jnp.ndarray, shape (N, )
+        Angular samples in radians. This could be the angular bins, or a batch of angular samples.
+    weights : jnp.ndarray, shape (..., N), optional
+        Non-negative sample weights. If omitted, all samples receive equal
+        weight.
+
+    Returns
+    -------
+    mean : jnp.ndarray, shape (...,)
+        Circular mean wrapped to ``[-pi, pi)``.
+    variance : jnp.ndarray, shape (...,)
+        Mean squared residual after wrapping residuals to ``[-pi, pi)``.
+    """
+    angles = jnp.asarray(angles)
+    if weights is None:
+        weights = jnp.ones_like(angles)
+    angles, weights = jnp.broadcast_arrays(angles, jnp.asarray(weights))
+
+    sums = weights.sum(axis=-1)
+    sin_mean = jnp.sum(weights * jnp.sin(angles), axis=-1) / sums
+    cos_mean = jnp.sum(weights * jnp.cos(angles), axis=-1) / sums
+    mean = _wrap_minuspi_pi(jnp.arctan2(sin_mean, cos_mean))
+
+    fallback_indices = jnp.argmax(weights, axis=-1)
+    fallback = jnp.take_along_axis(angles, fallback_indices[..., None], axis=-1)[..., 0]
+    resultant_squared = sin_mean**2 + cos_mean**2
+    mean = jnp.where(resultant_squared > 1e-12, mean, _wrap_minuspi_pi(fallback))
+
+    residuals = _wrap_minuspi_pi(angles - mean[..., None])
+    variance = jnp.sum(weights * residuals**2, axis=-1) / sums
+    return mean, variance
 
 
 def _bin_indices_minuspi_pi(theta: jax.Array, n_bins: int) -> jax.Array:

--- a/src/simpl/utils.py
+++ b/src/simpl/utils.py
@@ -184,12 +184,12 @@ def _fit_gaussian_circular(x: jax.Array, likelihoods: jax.Array) -> tuple[jax.Ar
 def fit_gaussian(
     x: jax.Array,
     likelihoods: jax.Array,
-    mode: str = "linear",
+    is_1D_angular: bool = False,
 ) -> tuple[jax.Array, jax.Array, jax.Array]:
     """Fits Gaussian moments to each of T likelihood distributions over spatial bins.
 
-    ``mode="linear"`` computes ordinary Euclidean weighted moments. For 1-D
-    angles in radians, ``mode="circular"`` computes the circular mean and the
+    Ordinary Euclidean weighted moments are used by default. When
+    ``is_1D_angular=True``, the function instead computes the circular mean and
     variance of wrapped residuals around that mean. The circular variance is in
     radians squared, making it suitable as observation noise for the wrapped
     Kalman filter.
@@ -213,9 +213,9 @@ def fit_gaussian(
         The position bins (shared across all time steps).
     likelihoods : jnp.ndarray, shape (T, N_bins)
         Likelihood values (not log) at each bin for each time step.
-    mode : {"linear", "circular"}, optional
-        Moment-fitting method. Circular mode only supports a one-dimensional
-        angular grid. By default ``"linear"`` for backwards compatibility.
+    is_1D_angular : bool, optional
+        Whether ``x`` is a one-dimensional angular grid. Angular data always
+        use circular moments. By default False.
 
     Returns
     -------
@@ -226,9 +226,7 @@ def fit_gaussian(
     covariances : jnp.ndarray, shape (T, D, D)
         The weighted covariance at each time step.
     """
-    if mode not in ("linear", "circular"):
-        raise ValueError(f"mode must be 'linear' or 'circular', got {mode!r}")
-    if mode == "circular":
+    if is_1D_angular:
         if x.ndim != 2 or x.shape[1] != 1:
             raise ValueError(f"Circular Gaussian fitting requires x with shape (N_bins, 1), got {x.shape}")
         return _fit_gaussian_circular(x, likelihoods)

--- a/src/simpl/utils.py
+++ b/src/simpl/utils.py
@@ -139,11 +139,62 @@ def gaussian_norm_const(sigma: jax.Array) -> jax.Array:
 
 
 @jax.jit
-def fit_gaussian(x: jax.Array, likelihoods: jax.Array) -> tuple[jax.Array, jax.Array, jax.Array]:
-    """Fits a multivariate-Gaussian to each of T likelihood distributions over spatial bins.
+def _fit_gaussian_linear(x: jax.Array, likelihoods: jax.Array) -> tuple[jax.Array, jax.Array, jax.Array]:
+    """Fit Euclidean Gaussian moments to likelihood distributions."""
+    sums = likelihoods.sum(axis=1)  # (T,)
 
-    For each timestep, computes the weighted mean, mode, and covariance of the
-    spatial bin coordinates ``x`` under the likelihood weights:
+    # Mean: weighted average via matmul
+    mu = (likelihoods @ x) / sums[:, None]  # (T, D)
+
+    # Mode: position of max likelihood
+    mode = x[jnp.argmax(likelihoods, axis=1)]  # (T, D)
+
+    # Covariance: E[xx^T] - mu mu^T (avoids (T, N_bins, D) intermediate)
+    x_outer = x[:, :, None] * x[:, None, :]  # (N_bins, D, D)
+    E_xxT = jnp.einsum("tb,bij->tij", likelihoods, x_outer) / sums[:, None, None]  # (T, D, D)
+    cov = E_xxT - mu[:, :, None] * mu[:, None, :]  # (T, D, D)
+
+    return mu, mode, cov
+
+
+@jax.jit
+def _fit_gaussian_circular(x: jax.Array, likelihoods: jax.Array) -> tuple[jax.Array, jax.Array, jax.Array]:
+    """Fit circular mean and wrapped residual variance to 1-D angular likelihoods."""
+    sums = likelihoods.sum(axis=1)  # (T,)
+    angles = x[:, 0]  # (N_bins,)
+
+    sin_mean = (likelihoods @ jnp.sin(angles)) / sums
+    cos_mean = (likelihoods @ jnp.cos(angles)) / sums
+    mu_angle = _wrap_minuspi_pi(jnp.arctan2(sin_mean, cos_mean))
+
+    mode = x[jnp.argmax(likelihoods, axis=1)]  # (T, 1)
+
+    # A circular mean is undefined for a distribution with zero resultant
+    # length. Use the likelihood mode as a deterministic centre in that case;
+    # the wrapped variance remains broad, so the Kalman update downweights it.
+    resultant_squared = sin_mean**2 + cos_mean**2
+    mu_angle = jnp.where(resultant_squared > 1e-12, mu_angle, mode[:, 0])
+
+    residuals = _wrap_minuspi_pi(angles[None, :] - mu_angle[:, None])
+    variance = jnp.sum(likelihoods * residuals**2, axis=1) / sums
+
+    return mu_angle[:, None], mode, variance[:, None, None]
+
+
+def fit_gaussian(
+    x: jax.Array,
+    likelihoods: jax.Array,
+    mode: str = "linear",
+) -> tuple[jax.Array, jax.Array, jax.Array]:
+    """Fits Gaussian moments to each of T likelihood distributions over spatial bins.
+
+    ``mode="linear"`` computes ordinary Euclidean weighted moments. For 1-D
+    angles in radians, ``mode="circular"`` computes the circular mean and the
+    variance of wrapped residuals around that mean. The circular variance is in
+    radians squared, making it suitable as observation noise for the wrapped
+    Kalman filter.
+
+    The linear mean and covariance are:
 
     $$\\mu_t = \\frac{\\sum_i x_i \\, p_{t,i}}{\\sum_i p_{t,i}}, \\qquad
     \\Sigma_t = \\mathbb{E}_t[x x^\\top] - \\mu_t \\mu_t^\\top$$
@@ -162,6 +213,9 @@ def fit_gaussian(x: jax.Array, likelihoods: jax.Array) -> tuple[jax.Array, jax.A
         The position bins (shared across all time steps).
     likelihoods : jnp.ndarray, shape (T, N_bins)
         Likelihood values (not log) at each bin for each time step.
+    mode : {"linear", "circular"}, optional
+        Moment-fitting method. Circular mode only supports a one-dimensional
+        angular grid. By default ``"linear"`` for backwards compatibility.
 
     Returns
     -------
@@ -172,20 +226,13 @@ def fit_gaussian(x: jax.Array, likelihoods: jax.Array) -> tuple[jax.Array, jax.A
     covariances : jnp.ndarray, shape (T, D, D)
         The weighted covariance at each time step.
     """
-    sums = likelihoods.sum(axis=1)  # (T,)
-
-    # Mean: weighted average via matmul
-    mu = (likelihoods @ x) / sums[:, None]  # (T, D)
-
-    # Mode: position of max likelihood
-    mode = x[jnp.argmax(likelihoods, axis=1)]  # (T, D)
-
-    # Covariance: E[xx^T] - mu mu^T (avoids (T, N_bins, D) intermediate)
-    x_outer = x[:, :, None] * x[:, None, :]  # (N_bins, D, D)
-    E_xxT = jnp.einsum("tb,bij->tij", likelihoods, x_outer) / sums[:, None, None]  # (T, D, D)
-    cov = E_xxT - mu[:, :, None] * mu[:, None, :]  # (T, D, D)
-
-    return mu, mode, cov
+    if mode not in ("linear", "circular"):
+        raise ValueError(f"mode must be 'linear' or 'circular', got {mode!r}")
+    if mode == "circular":
+        if x.ndim != 2 or x.shape[1] != 1:
+            raise ValueError(f"Circular Gaussian fitting requires x with shape (N_bins, 1), got {x.shape}")
+        return _fit_gaussian_circular(x, likelihoods)
+    return _fit_gaussian_linear(x, likelihoods)
 
 
 def gaussian_sample(key: jax.Array, mu: jax.Array, sigma: jax.Array) -> jax.Array:

--- a/src/simpl/utils.py
+++ b/src/simpl/utils.py
@@ -458,20 +458,12 @@ def correlation_at_lag(X1: jax.Array, X2: jax.Array, lag: int) -> jax.Array:
 # ──────────────────────────────────────────────────────────────────────────────
 
 
-def accumulate_spikes(
-    Y: np.ndarray,
-    window: int,
-    trial_boundaries: np.ndarray | None = None,
-    *,
-    trim_incomplete: bool = False,
-) -> np.ndarray | tuple[np.ndarray, np.ndarray, np.ndarray]:
+def accumulate_spikes(Y: np.ndarray, window: int) -> np.ndarray:
     """Causal rolling sum of spikes over a backward-looking window.
 
     Each time bin accumulates spikes from the current and previous
     ``window - 1`` bins. This is equivalent to smoothing the spikes with
-    a causal rectangular kernel. When ``trial_boundaries`` is provided, the
-    rolling window is reset at every trial start so spikes cannot leak between
-    trials.
+    a causal rectangular kernel.
 
     !!! warning
 
@@ -489,84 +481,17 @@ def accumulate_spikes(
     window : int
         Number of bins to sum over (looking backwards). For example,
         ``window=5`` sums the current bin and the 4 preceding bins.
-    trial_boundaries : np.ndarray or None, optional
-        Indices where trials start, e.g. ``[0, 1000, 2000]``. The first
-        boundary must be 0. If None, all bins are treated as one trial.
-    trim_incomplete : bool, optional
-        If True, remove the first ``window - 1`` bins of every trial, where a
-        complete backward-looking window is unavailable. Since accumulation is
-        causal, no bins need to be removed from trial ends. Trials shorter than
-        ``window`` are removed entirely because they contain no complete
-        accumulation window. This changes the return value to
-        ``(Y_accumulated, keep_mask, trial_boundaries)``. Use ``keep_mask`` to
-        trim aligned arrays such as ``Xb`` and ``time``. By default False.
 
     Returns
     -------
     Y_accumulated : np.ndarray, shape (T, N_neurons)
-        Spike counts after causal rolling sum. If ``trim_incomplete=True``, its
-        first dimension contains only bins backed by a complete accumulation
-        window; trials shorter than ``window`` contribute no bins.
-    keep_mask : np.ndarray, shape (T,), optional
-        Boolean mask selecting retained input bins. Returned only when
-        ``trim_incomplete=True``.
-    trial_boundaries : np.ndarray, optional
-        Trial starts recalculated for the trimmed concatenated data. Returned
-        only when ``trim_incomplete=True``.
-
-    Examples
-    --------
-    Accumulate independently within trials and trim all aligned arrays:
-
-    >>> Y_accum, keep, boundaries = accumulate_spikes(
-    ...     Y, window=3, trial_boundaries=boundaries, trim_incomplete=True
-    ... )
-    >>> Xb, time = Xb[keep], time[keep]
+        Spike counts after causal rolling sum.
     """
-    if isinstance(window, (bool, np.bool_)) or not isinstance(window, (int, np.integer)) or window < 1:
-        raise ValueError(f"window must be a positive integer, got {window!r}")
-
-    T = Y.shape[0]
-    if T == 0:
-        raise ValueError("Y must contain at least one time bin")
-
-    if trial_boundaries is None:
-        boundaries = np.array([0], dtype=int)
-    else:
-        boundaries = np.atleast_1d(np.asarray(trial_boundaries, dtype=int))
-
-    if boundaries.size == 0:
-        raise ValueError("trial_boundaries must contain at least one boundary (starting at 0)")
-    if boundaries[0] != 0:
-        raise ValueError("First trial boundary must be 0")
-    if boundaries[-1] >= T:
-        raise ValueError(f"Last trial boundary must be < len(Y) (got {boundaries[-1]} with len(Y)={T})")
-    if len(boundaries) > 1 and not np.all(np.diff(boundaries) > 0):
-        raise ValueError("Trial boundaries must be strictly increasing")
-
-    trial_ends = np.append(boundaries[1:], T)
     Y_out = np.zeros_like(Y)
-    for trial_start, trial_end in zip(boundaries, trial_ends):
-        for i in range(trial_start, trial_end):
-            window_start = max(trial_start, i - window + 1)
-            Y_out[i] = Y[window_start : i + 1].sum(axis=0)
-
-    if not trim_incomplete:
-        return Y_out
-
-    trimmed_trial_lengths = np.maximum(trial_ends - boundaries - (window - 1), 0)
-    retained_trial_lengths = trimmed_trial_lengths[trimmed_trial_lengths > 0]
-    if retained_trial_lengths.size == 0:
-        raise ValueError(
-            f"No trial contains at least window={window} bins, so no complete accumulation window can be retained"
-        )
-
-    keep_mask = np.zeros(T, dtype=bool)
-    for trial_start, trial_end in zip(boundaries, trial_ends):
-        keep_mask[trial_start + window - 1 : trial_end] = True
-
-    updated_boundaries = np.concatenate(([0], np.cumsum(retained_trial_lengths)[:-1])).astype(int)
-    return Y_out[keep_mask], keep_mask, updated_boundaries
+    for i in range(Y.shape[0]):
+        start = max(0, i - window + 1)
+        Y_out[i] = Y[start : i + 1].sum(axis=0)
+    return Y_out
 
 
 def coarsen_dt(

--- a/src/simpl/utils.py
+++ b/src/simpl/utils.py
@@ -497,16 +497,18 @@ def accumulate_spikes(
     trim_incomplete : bool, optional
         If True, remove the first ``window - 1`` bins of every trial, where a
         complete backward-looking window is unavailable. Since accumulation is
-        causal, no bins need to be removed from trial ends. This changes the
-        return value to ``(Y_accumulated, keep_mask, trial_boundaries)``. Use
-        ``keep_mask`` to trim aligned arrays such as ``Xb`` and ``time``. By
-        default False.
+        causal, no bins need to be removed from trial ends. Trials shorter than
+        ``window`` are removed entirely because they contain no complete
+        accumulation window. This changes the return value to
+        ``(Y_accumulated, keep_mask, trial_boundaries)``. Use ``keep_mask`` to
+        trim aligned arrays such as ``Xb`` and ``time``. By default False.
 
     Returns
     -------
     Y_accumulated : np.ndarray, shape (T, N_neurons)
         Spike counts after causal rolling sum. If ``trim_incomplete=True``, its
-        first dimension is shortened by ``window - 1`` bins per trial.
+        first dimension contains only bins backed by a complete accumulation
+        window; trials shorter than ``window`` contribute no bins.
     keep_mask : np.ndarray, shape (T,), optional
         Boolean mask selecting retained input bins. Returned only when
         ``trim_incomplete=True``.
@@ -554,19 +556,19 @@ def accumulate_spikes(
     if not trim_incomplete:
         return Y_out
 
-    trimmed_trial_lengths = trial_ends - boundaries - (window - 1)
-    if np.any(trimmed_trial_lengths <= 0):
-        short_trials = np.flatnonzero(trimmed_trial_lengths <= 0)
+    trimmed_trial_lengths = np.maximum(trial_ends - boundaries - (window - 1), 0)
+    retained_trial_lengths = trimmed_trial_lengths[trimmed_trial_lengths > 0]
+    if retained_trial_lengths.size == 0:
         raise ValueError(
-            f"Every trial must contain at least window={window} bins when trim_incomplete=True; "
-            f"trials {short_trials.tolist()} are too short"
+            f"No trial contains at least window={window} bins, so no complete "
+            "accumulation window can be retained"
         )
 
     keep_mask = np.zeros(T, dtype=bool)
     for trial_start, trial_end in zip(boundaries, trial_ends):
         keep_mask[trial_start + window - 1 : trial_end] = True
 
-    updated_boundaries = np.concatenate(([0], np.cumsum(trimmed_trial_lengths)[:-1])).astype(int)
+    updated_boundaries = np.concatenate(([0], np.cumsum(retained_trial_lengths)[:-1])).astype(int)
     return Y_out[keep_mask], keep_mask, updated_boundaries
 
 

--- a/tests/test_kde.py
+++ b/tests/test_kde.py
@@ -5,6 +5,7 @@ import numpy as np
 import pytest
 
 from simpl.kde import (
+    decode_observations,
     gaussian_kernel,
     kde,
     kde_angular,
@@ -106,6 +107,37 @@ class TestKDEAngular:
         # The peak should be near the pi/-pi boundary
         assert result.shape == (1, n_bins)
         assert jnp.all(jnp.isfinite(result))
+
+
+@pytest.mark.cpu_only
+class TestDecodeObservationsGaussianFitMode:
+    def test_linear_and_circular_modes_are_selectable(self):
+        n_bins = 64
+        xF = jnp.linspace(-jnp.pi, jnp.pi, n_bins, endpoint=False)[:, None]
+        angular_distance = jnp.angle(jnp.exp(1j * (xF[:, 0] - (jnp.pi - 0.02))))
+        mean_rate = (0.01 + 2.0 * jnp.exp(-0.5 * (angular_distance / 0.2) ** 2))[None, :]
+        spikes = jnp.array([[2.0]])
+        mask = jnp.ones_like(spikes, dtype=bool)
+
+        mu_linear, _, sigma_linear, _ = decode_observations(xF, spikes, mean_rate, mask, gaussian_fit_mode="linear")
+        mu_circular, _, sigma_circular, _ = decode_observations(
+            xF, spikes, mean_rate, mask, gaussian_fit_mode="circular"
+        )
+
+        assert jnp.abs(mu_linear[0, 0]) < 1.0
+        assert jnp.abs(mu_circular[0, 0]) > 2.5
+        assert sigma_circular[0, 0, 0] < sigma_linear[0, 0, 0]
+
+    def test_invalid_mode_raises(self):
+        xF = jnp.linspace(-1.0, 1.0, 10)[:, None]
+        with pytest.raises(ValueError, match="gaussian_fit_mode"):
+            decode_observations(
+                xF,
+                jnp.ones((1, 1)),
+                jnp.ones((1, 10)),
+                jnp.ones((1, 1), dtype=bool),
+                gaussian_fit_mode="invalid",
+            )
 
 
 class TestPoissonLogLikelihoodMaps:

--- a/tests/test_kde.py
+++ b/tests/test_kde.py
@@ -110,8 +110,8 @@ class TestKDEAngular:
 
 
 @pytest.mark.cpu_only
-class TestDecodeObservationsGaussianFitMode:
-    def test_linear_and_circular_modes_are_selectable(self):
+class TestDecodeObservationsAngularFit:
+    def test_angular_flag_forces_circular_fit(self):
         n_bins = 64
         xF = jnp.linspace(-jnp.pi, jnp.pi, n_bins, endpoint=False)[:, None]
         angular_distance = jnp.angle(jnp.exp(1j * (xF[:, 0] - (jnp.pi - 0.02))))
@@ -119,24 +119,22 @@ class TestDecodeObservationsGaussianFitMode:
         spikes = jnp.array([[2.0]])
         mask = jnp.ones_like(spikes, dtype=bool)
 
-        mu_linear, _, sigma_linear, _ = decode_observations(xF, spikes, mean_rate, mask, gaussian_fit_mode="linear")
-        mu_circular, _, sigma_circular, _ = decode_observations(
-            xF, spikes, mean_rate, mask, gaussian_fit_mode="circular"
-        )
+        mu_linear, _, sigma_linear, _ = decode_observations(xF, spikes, mean_rate, mask)
+        mu_circular, _, sigma_circular, _ = decode_observations(xF, spikes, mean_rate, mask, is_1D_angular=True)
 
         assert jnp.abs(mu_linear[0, 0]) < 1.0
         assert jnp.abs(mu_circular[0, 0]) > 2.5
         assert sigma_circular[0, 0, 0] < sigma_linear[0, 0, 0]
 
-    def test_invalid_mode_raises(self):
-        xF = jnp.linspace(-1.0, 1.0, 10)[:, None]
-        with pytest.raises(ValueError, match="gaussian_fit_mode"):
+    def test_angular_fit_requires_one_dimensional_grid(self):
+        xF = jnp.ones((10, 2))
+        with pytest.raises(ValueError, match="shape"):
             decode_observations(
                 xF,
                 jnp.ones((1, 1)),
                 jnp.ones((1, 10)),
                 jnp.ones((1, 1), dtype=bool),
-                gaussian_fit_mode="invalid",
+                is_1D_angular=True,
             )
 
 

--- a/tests/test_simpl.py
+++ b/tests/test_simpl.py
@@ -20,6 +20,8 @@ class TestSIMPLInit:
         assert model.is_fitted_ is False
         assert not hasattr(model, "Y_")
         assert not hasattr(model, "results_")
+        assert not hasattr(model, "gaussian_fit_mode")
+        assert not hasattr(model, "_gaussian_fit_mode")
 
     def test_speed_prior_none_disables_kalman_smoothing(self, demo_data):
         N = 500

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,6 +10,7 @@ from simpl.utils import (
     _AVAILABLE_DEMO_DATA,
     _bin_indices_minuspi_pi,
     _circular_conv_fft_1d,
+    _circular_mean_and_variance,
     _wrap_minuspi_pi,
     accumulate_spikes,
     analyse_place_fields,
@@ -115,6 +116,33 @@ class TestFitGaussian:
         assert mus.shape == (2, 1)
         assert jnp.allclose(mus[0], jnp.array([0.0]), atol=0.1)
         assert jnp.allclose(mus[1], jnp.array([1.0]), atol=0.1)
+
+
+class TestCircularMeanAndVariance:
+    def test_unweighted_samples_wrap_across_boundary(self):
+        angles = jnp.array([jnp.pi - 0.1, -jnp.pi + 0.1])
+
+        mean, variance = _circular_mean_and_variance(angles)
+
+        assert jnp.allclose(_wrap_minuspi_pi(mean - jnp.pi), 0.0, atol=1e-6)
+        assert jnp.allclose(variance, 0.01, atol=1e-6)
+
+    def test_zero_resultant_uses_first_angle_as_fallback(self):
+        mean, variance = _circular_mean_and_variance(jnp.array([0.0, jnp.pi]))
+
+        assert jnp.allclose(mean, 0.0, atol=1e-6)
+        assert jnp.allclose(variance, jnp.pi**2 / 2, atol=1e-6)
+
+    def test_broadcasts_shared_angles_over_weight_batches(self):
+        angles = jnp.array([jnp.pi - 0.1, -jnp.pi + 0.1, 0.0])
+        weights = jnp.array([[1.0, 1.0, 0.0], [0.0, 0.0, 1.0]])
+
+        means, variances = _circular_mean_and_variance(angles, weights)
+
+        assert means.shape == (2,)
+        assert variances.shape == (2,)
+        assert jnp.allclose(_wrap_minuspi_pi(means[0] - jnp.pi), 0.0, atol=1e-6)
+        assert jnp.allclose(variances, jnp.array([0.01, 0.0]), atol=1e-6)
 
 
 @pytest.mark.cpu_only


### PR DESCRIPTION
I modified the `fit_gaussian` and _per_trial_initial_states` to handle circular mode properly.

Also, `accumulate_spikes` with `trial_boundaries` was causing spike leak across temporally discontinuous trials, so I fixed that issue, too.