### PR TITLE
Remove dedicated `environment` argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,33 +79,33 @@ SIMPL follows sklearn conventions: configure hyperparameters at init, pass data 
 from simpl import SIMPL
 
 # 1. Load your data
-Y = ...     # spike counts (T, N_neurons)
-Xb = ...    # behavioural initialisation positions (T, D)
+Y = ...  # spike counts (T, N_neurons)
+Xb = ...  # behavioural initialisation positions (T, D)
 time = ...  # timestamps (T,) or use time = np.linspace(0, T_end, len(Y)) if length is known but timestamps aren't
 
 # 2. Configure the model (no data, no computation)
 model = SIMPL(
-    speed_prior=0.4,        # "0.4m/s" prior on latent speed
-    behavior_prior=None,    # (optional) soft tether to the initial behaviour/stimulus
+    speed_prior=0.4,  # "0.4m/s" prior on latent speed
+    behavior_prior=None,  # (optional) soft tether to the initial behaviour/stimulus
     kernel_bandwidth=0.02,  # "2 cm" kernel bandwidth for KDE spike smoothing
-    bin_size=0.02,          # "2 cm" spatial bin size for environment discretisation
+    bin_size=0.02,  # "2 cm" spatial bin size for environment discretisation
 )
 
 # 3. Fit
 model.fit(
-    Y,                      # spike counts
-    Xb,                     # behavioural initialisation positions
-    time,                   # timestamps
+    Y,  # spike counts
+    Xb,  # behavioural initialisation positions
+    time,  # timestamps
     n_iterations=5,
-    )
+)
 
 # 4. Access results
-model.X_           # final decoded latent positions, shape (T, D)
-model.F_           # final receptive fields, shape (N_neurons, *env_dims)
-model.results_     # full xarray.Dataset with metrics, likelihoods, and baselines, across iterations.
+model.X_  # final decoded latent positions, shape (T, D)
+model.F_  # final receptive fields, shape (N_neurons, *env_dims)
+model.results_  # full xarray.Dataset with metrics, likelihoods, and baselines, across iterations.
 
 # 5. Plot results
-model.plot_fitting_summary()  # Shows bits-per-spike metric and spike-latent mutual information. 
+model.plot_fitting_summary()  # Shows bits-per-spike metric and spike-latent mutual information.
 
 # (optional) Resume training if not yet converged
 model.fit(Y, Xb, time, n_iterations=5, resume=True)
@@ -293,9 +293,9 @@ model.analyse_place_fields()
 # Prediction on held-out data
 model.predict(Y_test)
 model.plot_prediction(
-  Xb=Xb_test, 
-  Xt=Xt_test, # Xt_test is optional ground truth for the prediction data
-  )
+    Xb=Xb_test,
+    Xt=Xt_test,  # Xt_test is optional ground truth for the prediction data
+)
 ```
 
 <p align="center">
@@ -332,6 +332,7 @@ model.save_results("results.nc")
 
 # Load results as an xr.Dataset for custom analysis
 from simpl import load_results
+
 results = load_results("results.nc")
 
 # Or rehydrate a full model for plotting, prediction, or resumed training
@@ -373,13 +374,12 @@ When `time=None`, SIMPL treats the data as non-temporal, replaces the missing ti
 <!-- docs-angular-start -->
 ### 1D angular / circular data
 
-SIMPL supports 1D circular latent variables (e.g. head direction) via the `is_1D_angular` flag. When enabled, the environment is fixed to [-π, π), angular KDE is used for receptive fields, and the Kalman filter wraps its state to [-π, π) after every predict, update, and smooth step.
+SIMPL supports 1D circular latent variables (e.g. head direction) via the `is_1D_angular` flag. When enabled, the environment is fixed to [-π, π), angular KDE is used for receptive fields, and the Kalman filter wraps its state to [-π, π) after every predict, update, and smooth step. Do not set `env_lims` or a nonzero `env_pad` in angular mode.
 
 ```python
 model = SIMPL(
     is_1D_angular=True,
     bin_size=np.pi / 32,
-    env_pad=0.0,
     speed_prior=0.1,
     kernel_bandwidth=0.3,
 )
@@ -434,9 +434,9 @@ pip install --force-reinstall -e ".[metal]"
 ```
 
 ```python
-model = SIMPL()               # use a GPU when available (default)
+model = SIMPL()  # use a GPU when available (default)
 model = SIMPL(use_gpu=False)  # force CPU
-model = SIMPL(use_gpu=True)   # require a GPU
+model = SIMPL(use_gpu=True)  # require a GPU
 ```
 
 With `use_gpu=False`, SIMPL selects CPU directly without initialising installed

--- a/examples/simpl_demo.ipynb
+++ b/examples/simpl_demo.ipynb
@@ -161,7 +161,6 @@
     "    kernel_bandwidth=0.025,\n",
     "    speed_prior=0.4,\n",
     "    bin_size=0.02,\n",
-    "    env_pad=0.0,\n",
     ")\n",
     "\n",
     "# Providing ground truth values as baselines allows direct comparison\n",
@@ -486,7 +485,6 @@
     "    kernel_bandwidth=0.1,\n",
     "    speed_prior=0.6,\n",
     "    bin_size=0.02,\n",
-    "    env_pad=0.0,\n",
     ")\n",
     "pc_model.fit(Y_pc, Xb_pc, time_pc, n_iterations=10)"
    ]
@@ -649,7 +647,6 @@
     "    speed_prior=100,\n",
     "    bin_size=2 * np.pi / 100,\n",
     "    is_1D_angular=True,\n",
-    "    env_pad=0,\n",
     "    behavior_prior=2.0,\n",
     ")\n",
     "hd_model.fit(Y_hd, Xb_hd, time_hd, n_iterations=20, trial_boundaries=trial_boundaries_hd)"

--- a/src/simpl/environment.py
+++ b/src/simpl/environment.py
@@ -11,10 +11,10 @@ Dimension naming convention:
 * 3-D: ``['x', 'y', 'z']``
 * Higher: ``['x1', 'x2', ..., 'xD']``
 
-Typically users do **not** create an ``Environment`` directly — ``SIMPL.fit()``
-builds one automatically from the data and the ``bin_size`` / ``env_pad``
-hyperparameters.  Power users may pass a pre-built ``Environment`` to
-``SIMPL.__init__`` for full control over the spatial grid.
+``SIMPL.fit()`` builds an ``Environment`` automatically from the data and the
+``bin_size``, ``env_pad``, and ``env_lims`` hyperparameters. ``SIMPL`` does not
+accept a pre-built environment. This class remains available directly for
+inspecting or plotting regular spatial grids.
 """
 
 import matplotlib.axes
@@ -23,66 +23,35 @@ import numpy as np
 
 
 class Environment:
-    """Basic environment class.
+    """Regular rectilinear grid used internally by SIMPL.
 
-    Key attributes are
-    - lims: the limits of the environment, a tuple of two tuples ((min_dim1, ..., min_dimD),(max_dim1, ..., max_dimD))
-    - extent : like lims but more matplotlib friendly, (min_dim1, max_dim1, min_dim2, max_dim2, ...)
-    - pad : how much the environment is padded, in m, outside the bounds of the behavior
-    - bin_size: the size of the bins in the environment
-    - D: the dimensionality of the environment
-    - dim : the names of the dimensions of the environment. Originating from the
-            spatial-maps origins of this code we use the following dimension
-            naming convention:
-            1D: ['x']
-            2D: ['x', 'y']
-            3D: ['x', 'y', 'z']
-            ...
-            DD: ['x1', 'x2', 'x3', ..., 'xD']
-    - coords_dict: a dictionary mapping the coordinate names to the coordinate
-            arrays in the environment. These a strictly increasing arrays of
-            the form ``np.linspace(lims[0][i], lims[1][i], N_bins)`` for each
-            dimension ``i``.
-    - dicretised_coords: an array of coordinates discretising the env,
-            flattened into shape (N_bins x D) where
-            (N_bins = N_xbins, x N_ybins x ...)
-    - discrete_env_shape: the shape of the discretised environment.
-            Specifically, _any_ array of shape (..., N_bins, ...) can be
-            reshaped to (..., N_xbins, N_ybins, N_zbins, ...). We always
-            recommend the following:
-        ```python
-        array = np.moveaxis(array, axis_of_size_N_bins, -1)
-        array = array.reshape(array.shape[:-1] + discrete_env_shape)
-        ```
-
-    A note on visualising environment variables: A 2D tensor reshaped to
-    discrete_env_shape and visualise (e.g. using matplotlib.imshow()) will
-    have x going down the rows and y going across the columns which is not
-    conventional. Instead you should swap the x and y dimensions then
-    reverse the y. Instead of plt.imshow(array) you should use
-    plt.imshow(array.T[::-1, :]). A BETTER way to do this is to try and
-    always store the array as a xarray with names dimensions and
-    coordinates.
-
-    Environments can optionally have a "plot_environment()" - this should
-    return an single matplotlib.Axes object with the environment (and
-    anything important) plotted on it. This is useful for visualising the
-    environment and used by the plotting module.
-
+    The grid covers either the data range plus ``pad`` or the explicit
+    ``force_lims``. Coordinates are bin centres spaced by ``bin_size``. SIMPL
+    constructs this class during ``SIMPL.fit``; an ``Environment`` instance
+    is not accepted by the ``SIMPL`` constructor.
 
     Parameters
     ----------
-    X : np.ndarray (T, D)
-        A sample of the latent variable, used to scale how big the environment is so it fits the data.
+    X : np.ndarray, shape (T, D)
+        Latent positions used to infer the grid limits when ``force_lims`` is None.
     pad : float, optional
-        How much the environment is padded outside the bounds of the behavior. Default is 0.1 m.
+        Padding outside the data bounds, in the same units as ``X``. Ignored
+        when ``force_lims`` is provided. By default 0.1.
     bin_size : float, optional
-        The size of the bins in the environment. Default is 0.02 m.
-    force_lims : tuple, optional
-        The limits of the environment, this will override those calculated
-        from Z and pad Z. Should be a two-tuple like
-        ((min_dim1, ..., min_dimD),(max_dim1, ..., max_dimD)).
-        Default is None."""
+        Grid spacing in the same units as ``X``. By default 0.02.
+    force_lims : tuple or None, optional
+        Explicit lower and upper limits formatted as
+        ``((min_dim1, ..., min_dimD), (max_dim1, ..., max_dimD))``. These
+        replace limits inferred from ``X``. By default None.
+    verbose : bool, optional
+        Whether to print a grid summary. By default True.
+
+    Notes
+    -----
+    ``discrete_env_shape`` gives the per-dimension grid shape,
+    ``flattened_discretised_coords`` has shape ``(N_bins, D)``, and
+    ``coords_dict`` maps dimension names to their one-dimensional coordinates.
+    """
 
     def __init__(
         self,

--- a/src/simpl/simpl.py
+++ b/src/simpl/simpl.py
@@ -41,7 +41,6 @@ class SIMPL:
         bin_size: float = 0.04,
         env_pad: float = 0.0,
         env_lims: tuple | None = None,
-        env: environment.Environment | None = None,
         # Mask and analysis parameters
         val_frac: float = 0.1,
         speckle_block_size_seconds: float = 1,
@@ -116,18 +115,14 @@ class SIMPL:
         env_pad : float, optional
             Padding added outside the data bounds when constructing the environment grid. This
             ensures that receptive fields near the boundary of the explored space are not
-            clipped. In the same units as the latent space. Ignored when
-            ``is_1D_angular=True`` because the circular domain is fixed to ``[-pi, pi)``.
-            By default 0.0.
+            clipped. In the same units as the latent space. Must be zero when ``env_lims`` is
+            supplied or ``is_1D_angular=True``. By default 0.0.
         env_lims : tuple or None, optional
             Force the environment limits to specific values instead of inferring them from the
             data. Format: ``((min_dim1, min_dim2, ...), (max_dim1, max_dim2, ...))``.
-            By default None (auto-inferred from ``Xb``). When ``is_1D_angular=True``, the
-            domain is fixed to ``[-pi, pi)`` and incompatible limits raise an error.
-        env : Environment or None, optional
-            A pre-built ``Environment`` instance for power users. If provided, ``bin_size``,
-            ``env_pad``, and ``env_lims`` are all ignored. In circular mode the provided
-            environment must also represent the full ``[-pi, pi)`` domain. By default None.
+            By default None (auto-inferred from ``Xb``). Mutually exclusive with nonzero
+            ``env_pad`` and unavailable when ``is_1D_angular=True``, whose domain is fixed to
+            ``[-pi, pi)``.
         val_frac : float, optional
             Fraction of spike observations held out for validation, implemented via a speckled
             (block-structured) mask. Used to compute held-out log-likelihood for monitoring
@@ -146,7 +141,7 @@ class SIMPL:
 
         Examples
         --------
-        >>> model = SIMPL(speed_prior=0.4, kernel_bandwidth=0.02, bin_size=0.02, env_pad=0.0)
+        >>> model = SIMPL(speed_prior=0.4, kernel_bandwidth=0.02, bin_size=0.02)
         >>> model.fit(Y, Xb, time, n_iterations=5)
         >>> print(model.X_.shape)  # decoded latent positions
         >>> print(model.F_.shape)  # fitted receptive fields
@@ -161,7 +156,6 @@ class SIMPL:
         self.bin_size = bin_size
         self.env_pad = env_pad
         self.env_lims = env_lims
-        self._environment_override = env  # power-user pre-built Environment
 
         # Mask and analysis parameters
         self.val_frac = val_frac
@@ -592,7 +586,7 @@ class SIMPL:
             original training run.** This method does NOT read or override
             hyperparameters from the saved file — it trusts whatever was passed to
             ``__init__``. If any parameter differs (``speed_prior``,
-            ``kernel_bandwidth``, ``bin_size``, ``env_pad``, ``val_frac``,
+            ``kernel_bandwidth``, ``bin_size``, ``env_pad``, ``env_lims``, ``val_frac``,
             ``random_seed``, etc.), the internal state (Kalman filter, spike mask,
             environment grid) will be inconsistent with the saved results, leading
             to silently incorrect behaviour on resume, predict, or further fitting.
@@ -1321,31 +1315,21 @@ class SIMPL:
         if self.is_1D_angular:
             if self.D_ != 1:
                 raise ValueError("Circular mode currently supports only 1D latent variables")
+            if self.env_lims is not None:
+                raise ValueError("env_lims cannot be set when is_1D_angular=True; the domain is fixed to [-pi, pi)")
+            if self.env_pad != 0:
+                raise ValueError("env_pad must be 0 when is_1D_angular=True; the domain is fixed to [-pi, pi)")
 
             circular_lims = ((-np.pi,), (np.pi,))
-            if self._environment_override is not None:
-                self.environment_ = self._environment_override
-            else:
-                if self.env_lims is not None:
-                    env_lims_array = np.asarray(self.env_lims, dtype=float)
-                    if not np.allclose(env_lims_array, circular_lims, atol=1e-6):
-                        raise ValueError("Circular mode requires env_lims to span the full [-pi, pi) domain")
-                if self.env_pad != 0:
-                    warnings.warn("env_pad is ignored when is_1D_angular=True; using the full [-pi, pi) domain.")
-                self.environment_ = environment.Environment(
-                    Xb, pad=0.0, bin_size=self.bin_size, force_lims=circular_lims, verbose=False
-                )
-
-            environment_lims = np.asarray(self.environment_.lims, dtype=float)
-            if self.environment_.D != 1 or not np.allclose(environment_lims, np.asarray(circular_lims), atol=1e-6):
-                raise ValueError("Circular mode requires an Environment spanning the full [-pi, pi) domain")
+            self.environment_ = environment.Environment(
+                Xb, pad=0.0, bin_size=self.bin_size, force_lims=circular_lims, verbose=False
+            )
         else:
-            if self._environment_override is not None:
-                self.environment_ = self._environment_override
-            else:
-                self.environment_ = environment.Environment(
-                    Xb, pad=self.env_pad, bin_size=self.bin_size, force_lims=self.env_lims, verbose=False
-                )
+            if self.env_lims is not None and self.env_pad != 0:
+                raise ValueError("env_pad must be 0 when env_lims is set; fixed limits already define the domain")
+            self.environment_ = environment.Environment(
+                Xb, pad=self.env_pad, bin_size=self.bin_size, force_lims=self.env_lims, verbose=False
+            )
 
         if self.D_ != self.environment_.D:
             raise ValueError(f"Data has {self.D_} dimensions but environment has {self.environment_.D}")
@@ -1910,7 +1894,6 @@ class SIMPL:
             "behavior_prior": np.nan if self.behavior_prior is None else self.behavior_prior,
             "is_1D_angular": int(self.is_1D_angular),
             "align_mode": self.align_mode_ or "none",
-            "environment_provided": int(self._environment_override is not None),
             "val_frac": self.val_frac,
             "speckle_block_size_seconds": self.speckle_block_size_seconds,
             "save_full_history": int(getattr(self, "save_full_history_", False)),

--- a/tests/test_simpl.py
+++ b/tests/test_simpl.py
@@ -6,7 +6,6 @@ import numpy as np
 import pytest
 import xarray as xr
 
-from simpl.environment import Environment
 from simpl.simpl import SIMPL
 from simpl.utils import load_results
 
@@ -125,19 +124,6 @@ class TestSIMPLFit:
         )
         assert model.environment_.bin_size == 0.03
         assert model.env_pad == 0.05
-
-    def test_fit_with_custom_environment(self, demo_data):
-        N = 500
-        N_neurons = min(5, demo_data["Y"].shape[1])
-        env = Environment(demo_data["Xb"][:N], bin_size=0.04)
-        model = SIMPL(env=env)
-        model.fit(
-            Y=demo_data["Y"][:N, :N_neurons],
-            Xb=demo_data["Xb"][:N],
-            time=demo_data["time"][:N],
-            n_iterations=0,
-        )
-        assert model.environment_ is env
 
     def test_fit_validates_shapes(self):
         model = SIMPL()
@@ -358,7 +344,6 @@ class TestSIMPLSaveLoadResults:
         assert model.results_.attrs["bin_size"] == 0.05
         assert model.results_.attrs["env_pad"] == 0.0
         np.testing.assert_allclose(model.results_.attrs["env_extent"], np.array([0.0, 1.0, 0.0, 1.0]))
-        assert model.results_.attrs["environment_provided"] == 0
         assert model.results_.attrs["val_frac"] == 0.2
         assert model.results_.attrs["speckle_block_size_seconds"] == 2.0
         assert model.results_.attrs["random_seed"] == 7
@@ -629,7 +614,7 @@ class TestSIMPLManifoldAlignment:
         rates = np.exp(3 * np.cos(Xb - preferred[None, :]))
         Y = rng.poisson(rates * 0.02)
 
-        model = SIMPL(is_1D_angular=True, bin_size=np.pi / 32, env_pad=0.0, speed_prior=0.1, kernel_bandwidth=0.3)
+        model = SIMPL(is_1D_angular=True, bin_size=np.pi / 32, speed_prior=0.1, kernel_bandwidth=0.3)
         model.fit(Y, Xb, time, n_iterations=1, align_to_behavior="fields")
         assert model.align_mode_ == "fields"
         assert "intercept" in model.E_
@@ -647,7 +632,7 @@ class TestSIMPLManifoldAlignment:
         rates = np.exp(3 * np.cos(Xb - preferred[None, :]))
         Y = rng.poisson(rates * 0.02)
 
-        model = SIMPL(is_1D_angular=True, bin_size=np.pi / 32, env_pad=0.0, speed_prior=0.1, kernel_bandwidth=0.3)
+        model = SIMPL(is_1D_angular=True, bin_size=np.pi / 32, speed_prior=0.1, kernel_bandwidth=0.3)
         model.fit(Y, Xb, time, n_iterations=1, align_to_behavior="trajectory")
         assert model.align_mode_ == "trajectory"
         assert "intercept" in model.E_
@@ -660,25 +645,36 @@ class TestSIMPLCircularEnvironment:
         time = np.arange(T) * 0.02
         Xb = np.linspace(-1.0, 1.0, T)[:, None]
         Y = np.zeros((T, N_neurons))
-        model = SIMPL(is_1D_angular=True, bin_size=np.pi / 32, env_pad=0.5, speckle_block_size_seconds=0.1)
+        model = SIMPL(is_1D_angular=True, bin_size=np.pi / 32, speckle_block_size_seconds=0.1)
 
-        with warnings.catch_warnings(record=True) as caught:
-            warnings.simplefilter("always")
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
             model.fit(Y, Xb, time, n_iterations=0)
 
-        assert any("env_pad is ignored" in str(w.message) for w in caught)
         assert np.allclose(model.environment_.lims[0], (-np.pi,))
         assert np.allclose(model.environment_.lims[1], (np.pi,))
 
-    def test_circular_fit_rejects_incompatible_env_lims(self):
+    @pytest.mark.parametrize("kwargs", [{"env_pad": 0.5}, {"env_lims": ((-np.pi,), (np.pi,))}])
+    def test_circular_fit_rejects_environment_overrides(self, kwargs):
         T, N_neurons = 200, 4
         time = np.arange(T) * 0.02
         Xb = np.linspace(-1.0, 1.0, T)[:, None]
         Y = np.zeros((T, N_neurons))
-        model = SIMPL(is_1D_angular=True, bin_size=np.pi / 32, env_lims=((-1.0,), (1.0,)))
+        model = SIMPL(is_1D_angular=True, bin_size=np.pi / 32, **kwargs)
 
-        with pytest.raises(ValueError, match=r"full \[-pi, pi\) domain"):
+        with pytest.raises(ValueError, match=r"domain is fixed to \[-pi, pi\)"):
             model.fit(Y, Xb, time, n_iterations=0)
+
+    def test_fixed_environment_limits_reject_padding(self, demo_data):
+        model = SIMPL(env_lims=((0.0, 0.0), (1.0, 1.0)), env_pad=0.1)
+
+        with pytest.raises(ValueError, match="env_pad must be 0 when env_lims is set"):
+            model.fit(
+                Y=demo_data["Y"][:200, :5],
+                Xb=demo_data["Xb"][:200],
+                time=demo_data["time"][:200],
+                n_iterations=0,
+            )
 
 
 class TestSIMPLPredict:


### PR DESCRIPTION
Remove `environment` argument from SIMPL initialisation. We never use it. Instead `bin_size`, `env_pad`, `env_lims` and `is_1D_circular` are sufficient controls. 