### PR TITLE
Default binsize

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ $K$ is a Gaussian kernel with bandwidth `kernel_bandwidth`. The denominator corr
 <!-- docs-model-units-start -->
 ### Units and Discretisation
 
-All hyperparameters (e.g. `speed_prior`, `kernel_bandwidth`, `bin_size` etc.) are defined in _data units_ (e.g. typically [m/s], [m], [m] but these depend on _your_ data of course), not arbitrary time/spatial-bin units. 
+All hyperparameters (e.g. `speed_prior`, `kernel_bandwidth`, `bin_size`) are defined in _data units_ (e.g. typically [m/s], [m], [m] but these depend on _your_ data of course), not arbitrary time/spatial-bin units. 
 <!-- docs-model-units-end -->
 
 <!-- docs-model-body-end -->

--- a/examples/simpl_demo.ipynb
+++ b/examples/simpl_demo.ipynb
@@ -137,7 +137,7 @@
     "Key hyperparameters:\n",
     "- `kernel_bandwidth` — KDE smoothing width for receptive field estimation (in data units)\n",
     "- `speed_prior` — how fast the latent can move (m/s); lower = smoother decoded trajectory\n",
-    "- `bin_size` — spatial resolution of the receptive field grid"
+    "- `bin_size` — spatial resolution of the receptive field grid; `\"auto\"` (default) uses 1/25 of the largest environment span"
    ]
   },
   {

--- a/src/simpl/environment.py
+++ b/src/simpl/environment.py
@@ -17,9 +17,14 @@ accept a pre-built environment. This class remains available directly for
 inspecting or plotting regular spatial grids.
 """
 
+import warnings
+
 import matplotlib.axes
 import matplotlib.pyplot as plt
 import numpy as np
+
+AUTO_BINS_PER_LARGEST_DIM = 25
+LARGE_GRID_WARNING_BINS = 100_000
 
 
 class Environment:
@@ -57,7 +62,7 @@ class Environment:
         self,
         X: np.ndarray,
         pad: float = 0.1,
-        bin_size: float = 0.02,
+        bin_size: float | str = 0.02,
         force_lims: tuple | None = None,
         verbose: bool = True,
     ) -> None:
@@ -81,6 +86,8 @@ class Environment:
             for i in range(2):
                 self.extent += (self.lims[i][d],)
 
+        if bin_size == "auto":
+            bin_size = np.max(np.subtract(self.lims[1], self.lims[0])) / AUTO_BINS_PER_LARGEST_DIM
         self.bin_size = bin_size
 
         # create dim names
@@ -106,6 +113,14 @@ class Environment:
         )  # (D, N_xbins, N_ybins, ...)
         self.discrete_env_shape = self.discretised_coords.shape[1:]
         self.flattened_discretised_coords = self.discretised_coords.reshape(self.D, -1).T
+
+        n_bins = self.flattened_discretised_coords.shape[0]
+        if n_bins > LARGE_GRID_WARNING_BINS:
+            warnings.warn(
+                f"The environment grid contains {n_bins:,} bins, which may require substantial compute and memory. "
+                "Consider using a larger bin_size.",
+                stacklevel=2,
+            )
 
         if verbose:
             print(

--- a/src/simpl/kde.py
+++ b/src/simpl/kde.py
@@ -518,7 +518,6 @@ def kde_angular(
     spikes = jnp.asarray(spikes)
 
     n_bins = bins.shape[0]
-    assert n_bins % 2 == 0, "n_bins should be even for FFT-based circular convolution."
     T = trajectory.shape[0]
     n_neurons = spikes.shape[1]
 
@@ -529,17 +528,14 @@ def kde_angular(
     # 1) bin indices consistent with [-pi, pi)
     idx = _bin_indices_minuspi_pi(trajectory, n_bins)  # (T,)
 
-    # 2) von Mises kernel over offsets in [-pi, pi)
-    # Build on symmetric grid => delta_theta=0 sits at index n_bins//2
-    dtheta = jnp.linspace(-jnp.pi, jnp.pi, n_bins, endpoint=False)
+    # 2) von Mises kernel over FFT-ordered circular offsets. This supports both
+    # odd and even bin counts, with zero displacement at index 0.
+    dtheta = 2 * jnp.pi * jnp.fft.fftfreq(n_bins)
     # Convert bandwidth (std in radians) to von Mises concentration.
     # kappa ~ 1/sigma^2 is a good approximation for kappa > 2 (sigma < ~0.7 rad).
     kappa = 1.0 / (kernel_bandwidth**2)
     vm = jnp.exp(kappa * jnp.cos(dtheta))
     vm = vm / jnp.sum(vm)
-
-    # Align for FFT: put delta_theta=0 at index 0
-    vm = jnp.roll(vm, -n_bins // 2)
 
     # 3) histogram per neuron using bincount (vmap over neurons)
     def hist_for_neuron(weights_t: jax.Array) -> jax.Array:

--- a/src/simpl/simpl.py
+++ b/src/simpl/simpl.py
@@ -19,6 +19,7 @@ Each EM iteration proceeds as:
 import os
 import shutil
 import warnings
+from typing import Literal
 
 import jax
 import jax.numpy as jnp
@@ -38,7 +39,7 @@ class SIMPL:
         behavior_prior: float | None = None,
         # Environment parameters
         is_1D_angular: bool = False,
-        bin_size: float = 0.04,
+        bin_size: float | Literal["auto"] = "auto",
         env_pad: float = 0.0,
         env_lims: tuple | None = None,
         # Mask and analysis parameters
@@ -108,10 +109,12 @@ class SIMPL:
             The wrapped Kalman approximation assumes a tight posterior (sigma << 2*pi);
             results may degrade when posterior uncertainty is large relative to the circular
             domain. By default False.
-        bin_size : float, optional
-            Spatial bin size for discretising the environment, in the same units as the latent
-            space. Controls the resolution of the receptive field grid. Smaller bins give
-            higher resolution but increase computation and memory. By default 0.04.
+        bin_size : float or "auto", optional
+            Spatial bin size for discretising the environment. A positive float is interpreted
+            in the same units as the latent space. ``"auto"`` uses 1/25 of the largest final
+            environment span, giving approximately 25 bins along its longest dimension. Smaller
+            bins give higher resolution but increase computation and memory. By default
+            ``"auto"``.
         env_pad : float, optional
             Padding added outside the data bounds when constructing the environment grid. This
             ensures that receptive fields near the boundary of the explored space are not
@@ -1330,6 +1333,8 @@ class SIMPL:
             self.environment_ = environment.Environment(
                 Xb, pad=self.env_pad, bin_size=self.bin_size, force_lims=self.env_lims, verbose=False
             )
+
+        self.bin_size_ = self.environment_.bin_size
 
         if self.D_ != self.environment_.D:
             raise ValueError(f"Data has {self.D_} dimensions but environment has {self.environment_.D}")

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -1,7 +1,9 @@
 """Tests for simpl.environment."""
 
 import numpy as np
+import pytest
 
+import simpl.environment as environment_module
 from simpl.environment import Environment
 
 
@@ -56,6 +58,18 @@ class TestEnvironmentBinSize:
         n_bins = env.discrete_env_shape[0]
         expected = int(np.ceil((1.0 - 0.0) / 0.1))
         assert abs(n_bins - expected) <= 1
+
+    def test_auto_bin_size(self):
+        X = np.array([[0.0], [1.0]])
+        env = Environment(X, pad=0.0, bin_size="auto")
+        assert env.bin_size == pytest.approx(0.04)
+        assert env.discrete_env_shape == (25,)
+
+    def test_large_grid_warns(self, monkeypatch):
+        monkeypatch.setattr(environment_module, "LARGE_GRID_WARNING_BINS", 10)
+        X = np.array([[0.0], [1.0]])
+        with pytest.warns(UserWarning, match="environment grid contains 25 bins"):
+            Environment(X, pad=0.0, bin_size="auto")
 
 
 class TestEnvironmentForceLims:

--- a/tests/test_kde.py
+++ b/tests/test_kde.py
@@ -91,10 +91,10 @@ class TestKDE:
 
 @pytest.mark.cpu_only
 class TestKDEAngular:
-    def test_smooth_output(self):
+    @pytest.mark.parametrize("n_bins", [20, 25])
+    def test_smooth_output(self, n_bins):
         np.random.seed(42)
         T = 500
-        n_bins = 20
         bins = jnp.linspace(-jnp.pi, jnp.pi, n_bins, endpoint=False)
         trajectory = jnp.array(np.random.uniform(-np.pi, np.pi, T))
         spikes = jnp.ones((T, 2))

--- a/tests/test_simpl.py
+++ b/tests/test_simpl.py
@@ -136,19 +136,6 @@ class TestSIMPLFit:
         assert model.environment_.bin_size == pytest.approx(0.04)
         assert model.environment_.discrete_env_shape == (25, 12)
 
-    def test_fit_with_custom_environment(self, demo_data):
-        N = 500
-        N_neurons = min(5, demo_data["Y"].shape[1])
-        env = Environment(demo_data["Xb"][:N], bin_size=0.04)
-        model = SIMPL(env=env)
-        model.fit(
-            Y=demo_data["Y"][:N, :N_neurons],
-            Xb=demo_data["Xb"][:N],
-            time=demo_data["time"][:N],
-            n_iterations=0,
-        )
-        assert model.environment_ is env
-
     def test_fit_validates_shapes(self):
         model = SIMPL()
         with pytest.raises(ValueError, match="same number of time bins"):
@@ -669,13 +656,9 @@ class TestSIMPLCircularEnvironment:
         time = np.arange(T) * 0.02
         Xb = np.linspace(-1.0, 1.0, T)[:, None]
         Y = np.zeros((T, N_neurons))
-        model = SIMPL(is_1D_angular=True, env_pad=0.5, speckle_block_size_seconds=0.1)
+        model = SIMPL(is_1D_angular=True, speckle_block_size_seconds=0.1)
+        model.fit(Y, Xb, time, n_iterations=0)
 
-        with warnings.catch_warnings():
-            warnings.simplefilter("error")
-            model.fit(Y, Xb, time, n_iterations=0)
-
-        assert any("env_pad is ignored" in str(w.message) for w in caught)
         assert model.bin_size_ == pytest.approx(2 * np.pi / 25)
         assert model.environment_.discrete_env_shape == (25,)
         assert np.allclose(model.environment_.lims[0], (-np.pi,))

--- a/tests/test_simpl.py
+++ b/tests/test_simpl.py
@@ -123,7 +123,31 @@ class TestSIMPLFit:
             n_iterations=0,
         )
         assert model.environment_.bin_size == 0.03
+        assert model.bin_size_ == 0.03
         assert model.env_pad == 0.05
+
+    def test_auto_bin_size_uses_largest_final_environment_span(self):
+        Xb = np.column_stack([np.linspace(0.0, 1.0, 200), np.linspace(0.2, 0.7, 200)])
+        model = SIMPL(speed_prior=None, speckle_block_size_seconds=0.1)
+        model.fit(np.zeros((200, 3)), Xb, np.arange(200) * 0.02, n_iterations=0)
+
+        assert model.bin_size == "auto"
+        assert model.bin_size_ == pytest.approx(0.04)
+        assert model.environment_.bin_size == pytest.approx(0.04)
+        assert model.environment_.discrete_env_shape == (25, 12)
+
+    def test_fit_with_custom_environment(self, demo_data):
+        N = 500
+        N_neurons = min(5, demo_data["Y"].shape[1])
+        env = Environment(demo_data["Xb"][:N], bin_size=0.04)
+        model = SIMPL(env=env)
+        model.fit(
+            Y=demo_data["Y"][:N, :N_neurons],
+            Xb=demo_data["Xb"][:N],
+            time=demo_data["time"][:N],
+            n_iterations=0,
+        )
+        assert model.environment_ is env
 
     def test_fit_validates_shapes(self):
         model = SIMPL()
@@ -177,7 +201,7 @@ class TestSIMPLFit:
             )
 
     def test_fit_validates_speckle_block_size_duration(self):
-        model = SIMPL(speckle_block_size_seconds=1.0)
+        model = SIMPL(bin_size=0.04, speckle_block_size_seconds=1.0)
         with pytest.raises(ValueError, match="shorter than the recording duration"):
             model.fit(
                 Y=np.zeros((10, 5)),
@@ -645,12 +669,15 @@ class TestSIMPLCircularEnvironment:
         time = np.arange(T) * 0.02
         Xb = np.linspace(-1.0, 1.0, T)[:, None]
         Y = np.zeros((T, N_neurons))
-        model = SIMPL(is_1D_angular=True, bin_size=np.pi / 32, speckle_block_size_seconds=0.1)
+        model = SIMPL(is_1D_angular=True, env_pad=0.5, speckle_block_size_seconds=0.1)
 
         with warnings.catch_warnings():
             warnings.simplefilter("error")
             model.fit(Y, Xb, time, n_iterations=0)
 
+        assert any("env_pad is ignored" in str(w.message) for w in caught)
+        assert model.bin_size_ == pytest.approx(2 * np.pi / 25)
+        assert model.environment_.discrete_env_shape == (25,)
         assert np.allclose(model.environment_.lims[0], (-np.pi,))
         assert np.allclose(model.environment_.lims[1], (np.pi,))
 


### PR DESCRIPTION
Makes default `bin_size="auto"` which uses 1/25th of the largest environment dimension. This makes SIMPL more robust to changes in the data scale